### PR TITLE
Fix gh-pages deployment conflict

### DIFF
--- a/.github/workflows/deploy-jupyterlite.yml
+++ b/.github/workflows/deploy-jupyterlite.yml
@@ -45,7 +45,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
-          force_orphan: true
 
       - name: Deploy PR Preview
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Problem

Deployment to gh-pages fails with conflict error:
```
cannot lock ref 'refs/heads/gh-pages': is at 7324d86... but expected 8c75d25...
```

This happens because `force_orphan: true` tries to overwrite the branch, but PR preview action has already pushed to it.

## Solution

Remove `force_orphan: true` to allow incremental updates to the existing gh-pages branch.

## Changes

- Remove `force_orphan: true` from peaceiris/actions-gh-pages configuration
- Deployment will now update the existing gh-pages branch instead of recreating it

## Result

Both main branch deployment and PR previews can coexist on the gh-pages branch.