### PR TITLE
Fix deployment conflict with PR previews

### DIFF
--- a/.github/workflows/deploy-jupyterlite.yml
+++ b/.github/workflows/deploy-jupyterlite.yml
@@ -45,6 +45,8 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
+          destination_dir: .
+          keep_files: true
 
       - name: Deploy PR Preview
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Problem

Main branch deployment fails with git push conflict:
```
cannot lock ref 'refs/heads/gh-pages': is at 1f892b4... but expected b332edf...
```

Both main deployment and PR preview actions try to write to gh-pages simultaneously.

## Solution

Add `keep_files: true` to preserve existing files (especially pr-preview directory) when deploying from main branch.

## Changes

- Add `keep_files: true` to peaceiris/actions-gh-pages
- Add `destination_dir: .` to explicitly deploy to root
- Main deployment will update root files without removing pr-preview folder

## Result

- Main branch: deploys to `/` (root)
- PR previews: deploy to `/pr-preview/pr-{number}/`
- Both coexist on gh-pages branch without conflicts