### PR TITLE
Fix gh-pages deployment conflicts

### DIFF
--- a/.github/workflows/deploy-jupyterlite.yml
+++ b/.github/workflows/deploy-jupyterlite.yml
@@ -51,7 +51,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
           destination_dir: .
-          keep_files: true
+          keep_files: false
+          force_orphan: true
 
       - name: Deploy PR Preview
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Problem

GitHub Actions deployment was failing with:
```
! [rejected]        gh-pages -> gh-pages (fetch first)
error: failed to push some refs
```

This happened when multiple builds (main branch push + PR preview) tried to update gh-pages simultaneously.

## Solution

- Set `force_orphan: true` to avoid merge conflicts
- Set `keep_files: false` for clean deployment
- This ensures each deployment is independent

## Testing

The workflow will run on this PR to verify the fix works.