### PR TITLE
Fix gh-pages deployment lock issue

### DIFF
--- a/.github/workflows/deploy-jupyterlite.yml
+++ b/.github/workflows/deploy-jupyterlite.yml
@@ -14,6 +14,11 @@ on:
       - closed
   workflow_dispatch:
 
+# Prevent concurrent deployments
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write
@@ -51,8 +56,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
           destination_dir: .
-          keep_files: false
-          force_orphan: true
+          keep_files: true
 
       - name: Deploy PR Preview
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Problem

Multiple workflows trying to deploy to gh-pages at the same time cause lock conflicts.

## Solution

Add concurrency control to queue deployments instead of running simultaneously:

```yaml
concurrency:
  group: pages
  cancel-in-progress: false
```

This ensures only one deployment runs at a time, preventing conflicts while keeping PR previews working.