### PR TITLE
Add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -5,9 +5,14 @@ on:
     types: [published]
 
 jobs:
-  build:
-    name: Build distribution
+  pypi-publish:
+    name: Upload release to PyPI
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyvista-js
+    permissions:
+      id-token: write
 
     steps:
     - uses: actions/checkout@v4
@@ -17,36 +22,11 @@ jobs:
       with:
         python-version: "3.x"
     
-    - name: Install build dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
+    - name: Install dependencies
+      run: python -m pip install --upgrade build
     
     - name: Build package
       run: python -m build
     
-    - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-
-  publish-to-pypi:
-    name: Publish to PyPI
-    needs: [build]
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/pyvista-js
-    permissions:
-      id-token: write
-
-    steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    
-    - name: Publish distribution to PyPI
+    - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to automatically publish the package to PyPI when a new release is created. The workflow uses trusted publishing (OIDC) for secure authentication.