### PR TITLE
Prepare release/0.1 - Bump version to 0.2.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyvista-js"
-version = "0.1.dev0"
+version = "0.2.dev0"
 description = "PyVista-like API for vtk.js"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
This PR merges the release/0.1 branch to main and bumps the version to 0.2.dev0 for the next development cycle.

## Changes
- Update version in pyproject.toml from 0.1.dev0 to 0.2.dev0

## Release Process
Following [PyVista's branching model](https://github.com/pyvista/pyvista/blob/main/CONTRIBUTING.rst#branching-model):

1. Merge this PR (`release/0.1` → `main`) to update the development version
2. Keep the `release/0.1` branch
3. Create a GitHub release with tag `v0.1.0` from the `release/0.1` branch
4. The automated workflow will publish v0.1.0 to PyPI
5. The `main` branch will continue development with version 0.2.dev0