### PR TITLE
ci: trigger tests on tag push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
     branches: [ main ]
     tags:
       - 'v*'  # Triggers on version tags like v1.0.0, v0.1.0, etc.
-      - '*'   # Triggers on any tag
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
This PR updates the CI workflow to trigger tests when tags are pushed to the repository. This allows CI validation when creating version tags like v1.0.0.