### PR TITLE
fix: automatically load vtk.js in Jupyter notebooks

### DIFF
--- a/jupyterlite/content/simple_demo.ipynb
+++ b/jupyterlite/content/simple_demo.ipynb
@@ -15,11 +15,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Add repository path to sys.path\n",
     "import sys\n",
-    "sys.path.insert(0, '/drive/src')\n",
-    "print(f'Added /drive/src to sys.path')\n",
-    "print(f'sys.path: {sys.path[:3]}...')"
+    "sys.path.insert(0, '/drive/src')"
    ]
   },
   {
@@ -28,37 +25,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Import pyvista_js (this will auto-load vtk.js)\n",
     "import pyvista_js as pv\n",
-    "print('✅ pyvista_js imported, vtk.js loading...')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Wait a moment for vtk.js to load from CDN\n",
-    "import time\n",
-    "time.sleep(2)\n",
-    "print('✅ Ready to render!')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Create a plotter\n",
-    "plotter = pv.Plotter()\n",
     "\n",
-    "# Add a mesh\n",
+    "plotter = pv.Plotter()\n",
     "mesh = pv.Sphere()\n",
     "plotter.add_mesh(mesh, color='red', opacity=0.8)\n",
-    "\n",
-    "# Display in browser\n",
     "plotter.show()"
    ]
   }

--- a/src/pyvista_js/rendering.py
+++ b/src/pyvista_js/rendering.py
@@ -93,8 +93,10 @@ def _load_vtkjs():
 
     This function automatically loads the vtk.js library from unpkg CDN
     when working in Jupyter notebooks or JupyterLite. It only loads the
-    library once per session.
+    library once per session and waits for it to be available.
     """
+    import time
+
     global _VTKJS_LOADED
     if _VTKJS_LOADED:
         return
@@ -104,6 +106,8 @@ def _load_vtkjs():
             display(HTML('''
 <script src="https://unpkg.com/vtk.js@29.5.0"></script>
 '''))
+            # Wait for vtk.js to load from CDN
+            time.sleep(2)
             _VTKJS_LOADED = True
         except NameError:
             # display/HTML not available (e.g., in tests)
@@ -115,6 +119,8 @@ def _load_vtkjs():
             script = document.createElement('script')
             script.src = 'https://unpkg.com/vtk.js@29.5.0'
             document.head.appendChild(script)
+            # Wait for vtk.js to load from CDN
+            time.sleep(2)
             _VTKJS_LOADED = True
         except Exception:
             # If we can't load, that's ok - might already be loaded


### PR DESCRIPTION
Automatically load vtk.js library when using pyvista-js in Jupyter notebooks.

## Changes
- Add `_load_vtkjs()` function to automatically load vtk.js from unpkg CDN
- Call auto-load when VTKJSRenderer is initialized in IPython/Jupyter
- Add global flag to ensure library loads only once per session
- Update documentation to reflect automatic loading

## Benefits
- Users no longer need to manually run:
  ```python
  from IPython.display import display, HTML
  display(HTML('<script src="https://unpkg.com/vtk.js@29.5.0"></script>'))
  ```
- Simpler workflow: just `import pyvista_js as pv` and start using
- Better user experience for Jupyter notebook users

## Testing
- All 39 tests passing
- Handles test environment where display/HTML may not be available