### PR TITLE
feat: add background_color property to Plotter

### DIFF
--- a/src/pyvista_js/plotter.py
+++ b/src/pyvista_js/plotter.py
@@ -28,6 +28,7 @@ class Plotter:
         """Initialize a new Plotter instance."""
         self._actors = []
         self._renderer = get_renderer()
+        self._background_color = (0.2, 0.3, 0.4)  # Default background color
 
     def add_mesh(
         self,
@@ -113,3 +114,93 @@ class Plotter:
     def actors(self):
         """Return the list of actors in the plotter."""
         return self._actors
+
+    @property
+    def background_color(self):
+        """Get or set the background color.
+
+        Parameters
+        ----------
+        color : str or tuple
+            Color name (e.g., 'white', 'black', 'red') or RGB tuple
+            with values between 0 and 1 (e.g., (1.0, 1.0, 1.0) for white).
+
+        Returns
+        -------
+        tuple
+            RGB color tuple with values between 0 and 1.
+
+        Examples
+        --------
+        >>> plotter = pv.Plotter()
+        >>> plotter.background_color = 'white'
+        >>> plotter.background_color
+        (1.0, 1.0, 1.0)
+        >>> plotter.background_color = (0.5, 0.5, 0.5)
+        """
+        return self._background_color
+
+    @background_color.setter
+    def background_color(self, color):
+        """Set the background color."""
+        self._background_color = self._parse_color(color)
+        # Update renderer's background color
+        self._renderer.set_background(self._background_color)
+
+    def _parse_color(self, color):
+        """Parse color input to RGB tuple.
+
+        Parameters
+        ----------
+        color : str or tuple
+            Color as string name or RGB tuple.
+
+        Returns
+        -------
+        tuple
+            RGB color tuple with values between 0 and 1.
+        """
+        # Common color names
+        color_map = {
+            'white': (1.0, 1.0, 1.0),
+            'black': (0.0, 0.0, 0.0),
+            'red': (1.0, 0.0, 0.0),
+            'green': (0.0, 1.0, 0.0),
+            'blue': (0.0, 0.0, 1.0),
+            'yellow': (1.0, 1.0, 0.0),
+            'cyan': (0.0, 1.0, 1.0),
+            'magenta': (1.0, 0.0, 1.0),
+            'gray': (0.5, 0.5, 0.5),
+            'grey': (0.5, 0.5, 0.5),
+            'orange': (1.0, 0.647, 0.0),
+            'purple': (0.5, 0.0, 0.5),
+            'pink': (1.0, 0.753, 0.796),
+            'brown': (0.647, 0.165, 0.165),
+        }
+
+        if isinstance(color, str):
+            color_lower = color.lower()
+            if color_lower in color_map:
+                return color_map[color_lower]
+            else:
+                raise ValueError(
+                    f"Unknown color name: '{color}'. "
+                    f"Supported colors: {', '.join(color_map.keys())}"
+                )
+        elif isinstance(color, (tuple, list)):
+            if len(color) != 3:
+                raise ValueError(
+                    f"RGB color must have 3 values, got {len(color)}"
+                )
+            # Validate values are between 0 and 1
+            for val in color:
+                if not 0 <= val <= 1:
+                    raise ValueError(
+                        f"RGB values must be between 0 and 1, got {val}"
+                    )
+            return tuple(color)
+        else:
+            raise TypeError(
+                f"Color must be a string or RGB tuple, got {type(color)}"
+            )
+

--- a/src/pyvista_js/rendering.py
+++ b/src/pyvista_js/rendering.py
@@ -185,6 +185,7 @@ class VTKJSRenderer:
         self.container = None
         self.actors = []
         self.use_ipython = IPYTHON_AVAILABLE
+        self.background = (0.2, 0.3, 0.4)  # Default background color
 
     def create_container(self, element_id="pyvista-container"):
         """Create a DOM container for rendering.
@@ -383,7 +384,7 @@ class VTKJSRenderer:
       // Use the simpler FullScreenRenderWindow helper
       const fullScreenRenderer = vtk.Rendering.Misc.vtkFullScreenRenderWindow.newInstance({{
         container: container,
-        background: [0.2, 0.3, 0.4]
+        background: [{self.background[0]}, {self.background[1]}, {self.background[2]}]
       }});
 
       const renderer = fullScreenRenderer.getRenderer();
@@ -424,6 +425,20 @@ class VTKJSRenderer:
         self.actors = []
         if not self.use_ipython and hasattr(self, 'renderer'):
             self.renderer.removeAllActors()
+
+    def set_background(self, color):
+        """Set the background color of the renderer.
+
+        Parameters
+        ----------
+        color : tuple
+            RGB color tuple with values between 0 and 1.
+
+        Examples
+        --------
+        >>> renderer.set_background((1.0, 1.0, 1.0))  # White background
+        """
+        self.background = color
 
     @staticmethod
     def _color_name_to_rgb(color_name):
@@ -493,6 +508,7 @@ class MockRenderer:
     def __init__(self):
         """Initialize mock renderer."""
         self.actors = []
+        self.background = (0.2, 0.3, 0.4)  # Default background color
 
     def create_container(self, element_id="pyvista-container"):
         """Mock container creation.
@@ -550,6 +566,17 @@ class MockRenderer:
         """
         self.actors = []
         print("Mock: Cleared all actors")
+
+    def set_background(self, color):
+        """Set the background color.
+
+        Parameters
+        ----------
+        color : tuple
+            RGB color tuple with values between 0 and 1.
+        """
+        self.background = color
+        print(f"Mock: Set background color to {color}")
 
 
 def get_renderer():

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -114,3 +114,97 @@ def test_plotter_all_mesh_types():
     assert 'Cube' in mesh_types
     assert 'Cylinder' in mesh_types
 
+
+def test_background_color_default():
+    """Test default background color."""
+    plotter = Plotter()
+    assert plotter.background_color == (0.2, 0.3, 0.4)
+
+
+def test_background_color_set_rgb():
+    """Test setting background color with RGB tuple."""
+    plotter = Plotter()
+    plotter.background_color = (1.0, 1.0, 1.0)
+    assert plotter.background_color == (1.0, 1.0, 1.0)
+    assert plotter._renderer.background == (1.0, 1.0, 1.0)
+
+
+def test_background_color_set_string():
+    """Test setting background color with color name."""
+    plotter = Plotter()
+    plotter.background_color = 'white'
+    assert plotter.background_color == (1.0, 1.0, 1.0)
+    assert plotter._renderer.background == (1.0, 1.0, 1.0)
+
+    plotter.background_color = 'black'
+    assert plotter.background_color == (0.0, 0.0, 0.0)
+    assert plotter._renderer.background == (0.0, 0.0, 0.0)
+
+    plotter.background_color = 'red'
+    assert plotter.background_color == (1.0, 0.0, 0.0)
+    assert plotter._renderer.background == (1.0, 0.0, 0.0)
+
+
+@pytest.mark.parametrize("color_name,expected_rgb", [
+    ('white', (1.0, 1.0, 1.0)),
+    ('black', (0.0, 0.0, 0.0)),
+    ('red', (1.0, 0.0, 0.0)),
+    ('green', (0.0, 1.0, 0.0)),
+    ('blue', (0.0, 0.0, 1.0)),
+    ('yellow', (1.0, 1.0, 0.0)),
+    ('cyan', (0.0, 1.0, 1.0)),
+    ('magenta', (1.0, 0.0, 1.0)),
+    ('gray', (0.5, 0.5, 0.5)),
+    ('grey', (0.5, 0.5, 0.5)),
+    ('orange', (1.0, 0.647, 0.0)),
+    ('purple', (0.5, 0.0, 0.5)),
+    ('pink', (1.0, 0.753, 0.796)),
+    ('brown', (0.647, 0.165, 0.165)),
+])
+def test_background_color_names(color_name, expected_rgb):
+    """Test all supported color names."""
+    plotter = Plotter()
+    plotter.background_color = color_name
+    assert plotter.background_color == expected_rgb
+    assert plotter._renderer.background == expected_rgb
+
+
+def test_background_color_invalid_name():
+    """Test setting background color with invalid color name."""
+    plotter = Plotter()
+    with pytest.raises(ValueError, match="Unknown color name"):
+        plotter.background_color = 'invalid_color'
+
+
+def test_background_color_invalid_rgb_length():
+    """Test setting background color with wrong RGB tuple length."""
+    plotter = Plotter()
+    with pytest.raises(ValueError, match="RGB color must have 3 values"):
+        plotter.background_color = (1.0, 1.0)
+
+
+def test_background_color_invalid_rgb_range():
+    """Test setting background color with RGB values out of range."""
+    plotter = Plotter()
+    with pytest.raises(ValueError, match="RGB values must be between 0 and 1"):
+        plotter.background_color = (1.5, 0.5, 0.5)
+
+    with pytest.raises(ValueError, match="RGB values must be between 0 and 1"):
+        plotter.background_color = (-0.1, 0.5, 0.5)
+
+
+def test_background_color_invalid_type():
+    """Test setting background color with invalid type."""
+    plotter = Plotter()
+    with pytest.raises(TypeError, match="Color must be a string or RGB tuple"):
+        plotter.background_color = 123
+
+
+def test_background_color_updates_renderer():
+    """Test that background color updates the renderer."""
+    plotter = Plotter()
+    plotter.background_color = 'white'
+
+    # Check that renderer was updated
+    assert plotter._renderer.background == (1.0, 1.0, 1.0)
+


### PR DESCRIPTION
## Description
This PR adds a `background_color` property to the Plotter class, similar to PyVista's plotter.background_color feature.

## Features
- ✅ Get/set background color using property decorator
- ✅ Support for color names (white, black, red, green, blue, yellow, cyan, magenta, gray, grey, orange, purple, pink, brown)
- ✅ Support for RGB tuples with values between 0 and 1
- ✅ Validation of color names and RGB values
- ✅ Background color propagated to vtk.js renderer
- ✅ Works with both VTKJSRenderer and MockRenderer

## Usage
```python
import pyvista_js as pv

plotter = pv.Plotter()

# Set background with color name
plotter.background_color = 'white'

# Or with RGB tuple
plotter.background_color = (0.0, 0.0, 0.0)  # Black

# Get current background color
color = plotter.background_color  # Returns (1.0, 1.0, 1.0)

plotter.add_mesh(pv.Sphere())
plotter.show()
```

## Tests
- Added 22 new tests covering:
  - Default background color
  - Setting with RGB tuples
  - Setting with color names
  - All 14 supported color names
  - Invalid color name error
  - Invalid RGB length error
  - RGB value range validation
  - Invalid type error
  - Renderer update verification
  
All 61 tests passing ✅