### PR TITLE
Add docs/ folder for PY004 compliance

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,38 @@
+# pyvista-js Documentation
+
+Welcome to pyvista-js documentation!
+
+## Overview
+
+pyvista-js is a PyVista-like API for vtk.js, bringing the intuitive PyVista interface to JavaScript-based 3D visualization.
+
+## Installation
+
+```bash
+pip install pyvista-js
+```
+
+## Quick Start
+
+```python
+import pyvista_js as pv
+
+# Create a simple sphere
+sphere = pv.Sphere()
+
+# Visualize it
+plotter = pv.Plotter()
+plotter.add_mesh(sphere)
+plotter.show()
+```
+
+## Features
+
+- PyVista-like API for familiar usage
+- Integration with vtk.js for web-based visualization
+- Support for JupyterLite and Streamlit
+
+## Links
+
+- [GitHub Repository](https://github.com/tkoyama010/pyvista-js)
+- [Issue Tracker](https://github.com/tkoyama010/pyvista-js/issues)


### PR DESCRIPTION
This PR adds a `docs/` folder to comply with the Scientific Python PY004 guideline.

## Changes
- Created `docs/` directory
- Added `docs/index.md` with basic documentation structure

## Reference
- [PY004 Guideline](https://learn.scientific-python.org/development/guides/packaging-simple#PY004)

## Compliance
This change addresses the PY004 recommendation: "You should have a `docs/` folder"