### PR TITLE
ci: Add pytest configuration to pyproject.toml (PP301-PP309)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,20 @@ Issues = "https://github.com/tkoyama010/pyvista-js/issues"
 [tool.hatch.build.targets.wheel]
 packages = ["src/pyvista_js"]
 
+[tool.pytest.ini_options]
+minversion = "6.0"
+testpaths = ["tests"]
+log_cli_level = "INFO"
+xfail_strict = true
+addopts = [
+    "-ra",
+    "--strict-config",
+    "--strict-markers",
+]
+filterwarnings = [
+    "error",
+]
+
 [tool.ruff]
 line-length = 100
 


### PR DESCRIPTION
Add comprehensive pytest configuration to satisfy scientific-python checks PP301-PP309.

Configuration includes: minimum version 6.0, test paths, log level, strict markers/config, xfail_strict, summary flags, and warning filters.