### PR TITLE
fix: use hukkin/mdformat instead of executablebooks/mdformat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: python-use-type-annotations
       - id: text-unicode-replacement-char
 
-  - repo: https://github.com/executablebooks/mdformat
+  - repo: https://github.com/hukkin/mdformat
     rev: 0.7.21
     hooks:
       - id: mdformat


### PR DESCRIPTION
Fixes PC180 pre-commit check by switching from the deprecated `executablebooks/mdformat` to the recommended `hukkin/mdformat` repository as specified in the scientific-python style guide.

This addresses the pre-commit violation:
- PC180: Uses a markdown formatter - Use https://github.com/hukkin/mdformat instead of https://github.com/executablebooks/mdformat

The change maintains the same revision (0.7.21) and hook configuration, only updating the repository URL.