### PR TITLE
fix: Add log_level to pytest configuration (PP304)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ lint.flake8-pytest-style.parametrize-values-type = "list"
 [tool.pytest]
 ini_options.minversion = "6.0"
 ini_options.testpaths = [ "tests" ]
+ini_options.log_level = "INFO"
 ini_options.log_cli_level = "INFO"
 ini_options.xfail_strict = true
 ini_options.addopts = [


### PR DESCRIPTION
Fixes PP304 by adding `log_level = "INFO"` to the pytest configuration.

This setting allows logs to be displayed on test failures, following the [scientific-python development guidelines](https://learn.scientific-python.org/development/guides/pytest#PP304).

Changes:
- Added `ini_options.log_level = "INFO"` to `[tool.pytest]` section in pyproject.toml