### PR TITLE
fix: FileNotFoundError for cylinder_source.js in JupyterLite

### DIFF
--- a/src/pyvista_js/mesh.py
+++ b/src/pyvista_js/mesh.py
@@ -5,7 +5,7 @@ Provides geometric primitives and mesh handling compatible with PyVista API.
 
 from __future__ import annotations
 
-from importlib.resources import files
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -13,12 +13,12 @@ import numpy as np
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike
 
-# Load JavaScript templates using importlib.resources for Pyodide compatibility
-_js_files = files("pyvista_js") / "js"
-_MESH_SOURCE_TEMPLATE = (_js_files / "mesh_source.js").read_text()
-_SPHERE_SOURCE_TEMPLATE = (_js_files / "sphere_source.js").read_text()
-_CUBE_SOURCE_TEMPLATE = (_js_files / "cube_source.js").read_text()
-_CYLINDER_SOURCE_TEMPLATE = (_js_files / "cylinder_source.js").read_text()
+# Load JavaScript templates relative to this file
+_JS_DIR = Path(__file__).parent / "js"
+_MESH_SOURCE_TEMPLATE = (_JS_DIR / "mesh_source.js").read_text()
+_SPHERE_SOURCE_TEMPLATE = (_JS_DIR / "sphere_source.js").read_text()
+_CUBE_SOURCE_TEMPLATE = (_JS_DIR / "cube_source.js").read_text()
+_CYLINDER_SOURCE_TEMPLATE = (_JS_DIR / "cylinder_source.js").read_text()
 
 
 class Mesh:


### PR DESCRIPTION
## Summary

- Replace `importlib.resources.files('pyvista_js')` with `Path(__file__).parent` in `mesh.py` for loading JS templates, consistent with how `rendering.py` already does it.

## Root Cause

In Pyodide/JupyterLite with `sys.path.insert(0, '/drive/src')`, `importlib.resources.files('pyvista_js')` can resolve to the **micropip-installed** package location rather than the source directory at `/drive/src/pyvista_js/`. If the installed wheel does not include the `js/` directory (or the JupyterLite filesystem does not serve it), the template files are not found.

Using `Path(__file__).parent` always resolves relative to the current source file, so it correctly points to `/drive/src/pyvista_js/` regardless of where micropip installed the package.

## Error Fixed

```
FileNotFoundError: [Errno 44] No such file or directory: '/drive/src/pyvista_js/js/cylinder_source.js'
```

## Changes

- `mesh.py`: replace `from importlib.resources import files` + `files("pyvista_js") / "js"` with `from pathlib import Path` + `Path(__file__).parent / "js"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)