### PR TITLE
docs: freeze versions in docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-sphinx>=7.0
-sphinx-book-theme>=1.0
-myst-parser>=2.0
-jupyterlite-sphinx>=0.13.0
-jupyterlite-pyodide-kernel>=0.4.0
+sphinx==9.1.0
+sphinx-book-theme==1.1.4
+myst-parser==5.0.0
+jupyterlite-sphinx==0.22.1
+jupyterlite-pyodide-kernel==0.7.1


### PR DESCRIPTION
## Summary

- Pin all documentation dependencies to their current latest versions using `==` instead of `>=`
- Ensures reproducible documentation builds

| Package | Before | After |
|---|---|---|
| sphinx | `>=7.0` | `==9.1.0` |
| sphinx-book-theme | `>=1.0` | `==1.1.4` |
| myst-parser | `>=2.0` | `==5.0.0` |
| jupyterlite-sphinx | `>=0.13.0` | `==0.22.1` |
| jupyterlite-pyodide-kernel | `>=0.4.0` | `==0.7.1` |

## Test plan

- [x] Verify docs build successfully with the pinned versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)