### PR TITLE
feat: set default background color to white

### DIFF
--- a/src/pyvista_js/plotter.py
+++ b/src/pyvista_js/plotter.py
@@ -35,7 +35,7 @@ class Plotter:
         """Initialize a new Plotter instance."""
         self._actors: list[dict[str, object]] = []
         self._renderer = get_renderer()
-        self._background_color = (0.2, 0.3, 0.4)  # Default background color
+        self._background_color = (1.0, 1.0, 1.0)  # Default background color
         self._container_id = f"pyvista-container-{uuid.uuid4().hex[:8]}"
 
     def add_mesh(

--- a/src/pyvista_js/rendering.py
+++ b/src/pyvista_js/rendering.py
@@ -210,7 +210,7 @@ class VTKJSRenderer:
         self.container = None
         self.actors: list[dict[str, object]] = []
         self.use_ipython = IPYTHON_AVAILABLE
-        self.background = (0.2, 0.3, 0.4)  # Default background color
+        self.background = (1.0, 1.0, 1.0)  # Default background color
         self._view_vector: tuple[float, float, float] | None = None
         self._view_up: tuple[float, float, float] = (0.0, 1.0, 0.0)
 
@@ -504,7 +504,7 @@ class MockRenderer:
     def __init__(self) -> None:
         """Initialize mock renderer."""
         self.actors: list[dict[str, object]] = []
-        self.background = (0.2, 0.3, 0.4)  # Default background color
+        self.background = (1.0, 1.0, 1.0)  # Default background color
         self._view_vector: tuple[float, float, float] | None = None
         self._view_up: tuple[float, float, float] = (0.0, 1.0, 0.0)
 

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -118,7 +118,7 @@ def test_plotter_all_mesh_types() -> None:
 def test_background_color_default() -> None:
     """Test default background color."""
     plotter = Plotter()
-    assert plotter.background_color == (0.2, 0.3, 0.4)
+    assert plotter.background_color == (1.0, 1.0, 1.0)
 
 
 def test_background_color_set_rgb() -> None:


### PR DESCRIPTION
Change the default background color from `(0.2, 0.3, 0.4)` to white `(1.0, 1.0, 1.0)`, matching PyVista's default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)