### PR TITLE
docs: add star history chart to Contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ plotter.show()
 
 ## Contributing
 
+Enjoying pyvista-js? Show your support with a GitHub star — it's a simple click that means the world to us and helps others discover it, too!
+
+<picture>
+  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tkoyama010/pyvista-js&type=Date">
+  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tkoyama010/pyvista-js&type=Date&theme=dark">
+  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=tkoyama010/pyvista-js&type=Date">
+</picture>
+
 Contributions are welcome! Please open an issue or pull request on [GitHub](https://github.com/tkoyama010/pyvista-js/issues).
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
@@ -73,14 +81,6 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 <!-- prettier-ignore-end -->
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
-
-Enjoying pyvista-js? Show your support with a GitHub star — it's a simple click that means the world to us and helps others discover it, too!
-
-<picture>
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tkoyama010/pyvista-js&type=Date">
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tkoyama010/pyvista-js&type=Date&theme=dark">
-  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=tkoyama010/pyvista-js&type=Date">
-</picture>
 
 ## License
 


### PR DESCRIPTION
## Summary

- Adds a star history chart (light/dark mode aware) to the Contributing section, styled after [bjlittle/geovista](https://github.com/bjlittle/geovista/tree/main?tab=readme-ov-file#star-history)
- Includes a short call-to-action message encouraging users to star the repo
- No new section heading — content sits naturally within Contributing

🤖 Generated with [Claude Code](https://claude.com/claude-code)