### PR TITLE
docs: add Code of Conduct badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![JupyterLite](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://tkoyama010.github.io/pyvista-js/)
 ![All Contributors](https://img.shields.io/github/all-contributors/tkoyama010/pyvista-js?color=ee8449)
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg)](https://github.com/RichardLitt/standard-readme)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-3.0-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 [PyVista](https://github.com/pyvista/pyvista)-like API for [vtk.js](https://github.com/Kitware/vtk-js) — bring intuitive 3D visualization to the browser.
 


### PR DESCRIPTION
## Summary

- Add Contributor Covenant 3.0 badge to README.md linking to the existing `CODE_OF_CONDUCT.md`

## Test plan

- [x] Verify badge renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)