### PR TITLE
docs: add GitHub Discussions badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg)](https://github.com/RichardLitt/standard-readme)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-3.0-4baaaa.svg)](CODE_OF_CONDUCT.md)
 [![zizmor](https://img.shields.io/badge/%F0%9F%8C%88-zizmor-white?labelColor=white)](https://zizmor.sh/)
+[![Join the community](https://img.shields.io/badge/Join%20the%20community-on%20GitHub%20Discussions-blue)](https://github.com/tkoyama010/pyvista-js/discussions)
 
 [PyVista](https://github.com/pyvista/pyvista)-like API for [vtk.js](https://github.com/Kitware/vtk-js) — bring intuitive 3D visualization to the browser.
 


### PR DESCRIPTION
## Summary
- Add "Join the community on GitHub Discussions" badge to README.md

## Test plan
- [x] Verify badge renders correctly in README
- [x] Verify badge links to https://github.com/tkoyama010/pyvista-js/discussions

🤖 Generated with [Claude Code](https://claude.com/claude-code)