### PR TITLE
docs: add Diátaxis badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg)](https://github.com/RichardLitt/standard-readme)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-3.0-4baaaa.svg)](CODE_OF_CONDUCT.md)
 [![zizmor](https://img.shields.io/badge/%F0%9F%8C%88-zizmor-white?labelColor=white)](https://zizmor.sh/)
+[![Diátaxis](https://img.shields.io/badge/Documentation-Di%C3%A1taxis-blue.svg?style=flat)](https://diataxis.fr/)
 [![Join the community](https://img.shields.io/badge/Join%20the%20community-on%20GitHub%20Discussions-blue)](https://github.com/tkoyama010/pyvista-js/discussions)
 
 [PyVista](https://github.com/pyvista/pyvista)-like API for [vtk.js](https://github.com/Kitware/vtk-js) — bring intuitive 3D visualization to the browser.


### PR DESCRIPTION
## Summary
- Add Diátaxis documentation badge to README badges section
- Links to https://diataxis.fr/ to indicate the project follows the Diátaxis documentation framework

## Test plan
- [x] Badge renders correctly in markdown
- [x] Badge links to https://diataxis.fr/

🤖 Generated with [Claude Code](https://claude.com/claude-code)