### PR TITLE
fix: update bootstrap-sha to correct commit

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -22,5 +22,5 @@
       ]
     }
   },
-  "bootstrap-sha": "92cd85c3d4e0e3e9e1e5c6e7e8e9e0e1e2e3e4e5"
+  "bootstrap-sha": "0a06d715a541ab9ad2c88dbab6b104b8d4097409"
 }


### PR DESCRIPTION
Fixes the bootstrap-sha in release-please config to use the actual commit SHA instead of a placeholder.

This should resolve the startup_failure in the release-please workflow.