### PR TITLE
feat: add download_masonry_texture to examples

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -86,6 +86,7 @@ This section provides detailed documentation for the pyvista-js public API.
    :nosignatures:
 
    pyvista_js.examples.CubeMap
+   pyvista_js.examples.download_masonry_texture
    pyvista_js.examples.download_sky_box_cube_map
 ```
 

--- a/src/pyvista_js/examples.py
+++ b/src/pyvista_js/examples.py
@@ -6,6 +6,8 @@ Provides download helpers for standard datasets, mirroring the
 
 from __future__ import annotations
 
+from pyvista_js.texture import Texture
+
 _PYVISTA_DATA_BASE = "https://raw.githubusercontent.com/pyvista/vtk-data/master/Data"
 
 
@@ -108,3 +110,28 @@ def download_sky_box_cube_map() -> CubeMap:
         posz=f"{base}/skybox2-posz.jpg",
         negz=f"{base}/skybox2-negz.jpg",
     )
+
+
+def download_masonry_texture() -> Texture:
+    """Download the masonry texture dataset.
+
+    Downloads a brick masonry image from the PyVista data repository
+    and returns it as a :class:`~pyvista_js.texture.Texture` object.
+
+    Returns
+    -------
+    Texture
+        Texture wrapping the masonry image URL.
+
+    Examples
+    --------
+    >>> import pyvista_js as pv
+    >>> from pyvista_js import examples
+    >>> texture = examples.download_masonry_texture()
+    >>> surf = pv.Cylinder()
+    >>> plotter = pv.Plotter()
+    >>> plotter.add_mesh(surf, texture=texture)
+    >>> plotter.show()
+
+    """
+    return Texture(f"{_PYVISTA_DATA_BASE}/masonry.bmp")


### PR DESCRIPTION
## Summary

- Adds `download_masonry_texture()` to `pyvista_js.examples`, mirroring [`pyvista.examples.downloads.download_masonry_texture`](https://docs.pyvista.org/api/examples/_autosummary/pyvista.examples.downloads.download_masonry_texture)
- Returns a `Texture` wrapping the `masonry.bmp` URL from the PyVista vtk-data repository
- Adds the function to the API reference docs

## Usage

```python
import pyvista_js as pv
from pyvista_js import examples

texture = examples.download_masonry_texture()
surf = pv.Cylinder()
plotter = pv.Plotter()
plotter.add_mesh(surf, texture=texture)
plotter.show()
```

## Test plan

- [x] Verify `download_masonry_texture()` returns a `Texture` instance
- [x] Verify the URL resolves to `https://raw.githubusercontent.com/pyvista/vtk-data/master/Data/masonry.bmp`
- [x] Verify the texture renders correctly on a `Cylinder` mesh

🤖 Generated with [Claude Code](https://claude.com/claude-code)