### PR TITLE
ci: add Conventional Commits PR title check

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,33 @@
+name: Conventional Commits
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ opened, edited, synchronize, reopened ]
+
+permissions: {}
+
+jobs:
+  check-pr-title:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Check PR title follows Conventional Commits
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017  # v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false


### PR DESCRIPTION
## Summary

- Add CI to check that PR titles follow the Conventional Commits specification
- Uses the `amannn/action-semantic-pull-request` action
- Supported types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`

## Test plan

- [x] Verify CI passes when the PR title follows Conventional Commits format (e.g. `feat: add something`)
- [x] Verify CI fails when the PR title does not follow the specification

🤖 Generated with [Claude Code](https://claude.com/claude-code)