### PR TITLE
chore: use Conventional Commits for pre-commit.ci messages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,12 +74,12 @@ repos:
 
 ci:
   autofix_commit_msg: |
-    [pre-commit.ci] auto fixes from pre-commit.com hooks
+    chore: auto fixes from pre-commit.com hooks
 
     for more information, see https://pre-commit.ci
   autofix_prs: true
   autoupdate_branch: ''
-  autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+  autoupdate_commit_msg: 'chore: pre-commit autoupdate'
   autoupdate_schedule: weekly
   skip: []
   submodules: false


### PR DESCRIPTION
## Summary
- Update `autofix_commit_msg` from `[pre-commit.ci] auto fixes...` to `chore: auto fixes...`
- Update `autoupdate_commit_msg` from `[pre-commit.ci] pre-commit autoupdate` to `chore: pre-commit autoupdate`
- Aligns pre-commit.ci bot messages with the Conventional Commits PR title check added in #162

## Test plan
- [ ] Verify next pre-commit.ci autoupdate PR uses `chore:` prefix
- [ ] Verify next pre-commit.ci autofix commit uses `chore:` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)