### PR TITLE
fix: install pyvista-js package in update-preview workflow

### DIFF
--- a/.github/workflows/update-preview.yml
+++ b/.github/workflows/update-preview.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: |
-          pip install playwright "imageio[ffmpeg]" pillow
+          pip install . playwright "imageio[ffmpeg]" pillow
           playwright install chromium
       - run: python -m pyvista_js capture-preview
       - uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403  # v5


### PR DESCRIPTION
## Summary
- The `update-preview` workflow failed because `pyvista_js` was not installed before running `python -m pyvista_js capture-preview`
- Add `pip install .` to install the package alongside playwright and imageio

## Test plan
- [ ] Verify `update-preview` workflow succeeds via `workflow_dispatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)