### PR TITLE
fix: use double-click to open notebook in preview capture

### DIFF
--- a/src/pyvista_js/_cli.py
+++ b/src/pyvista_js/_cli.py
@@ -245,8 +245,8 @@ def _open_notebook(page, screenshots_dir: Path) -> bool:  # noqa: ANN001
     for selector in notebook_selectors:
         element = page.query_selector(selector)
         if element is not None:
-            element.click()
-            logger.info("Clicked on notebook using selector: %s", selector)
+            element.dblclick()
+            logger.info("Double-clicked on notebook using selector: %s", selector)
             return True
 
     logger.warning("Could not find notebook, taking screenshot of main page")


### PR DESCRIPTION
## Summary
- The preview GIF only showed the JupyterLite launcher page because the notebook file was single-clicked (selected) but never opened
- JupyterLite requires a double-click to open files from the file browser
- Change `element.click()` to `element.dblclick()` in `_open_notebook`

## Test plan
- [ ] Run `workflow_dispatch` on `update-preview` and verify the GIF shows the notebook with 3D rendering, not just the launcher page

🤖 Generated with [Claude Code](https://claude.com/claude-code)