### PR TITLE
fix: match Sphere point generation to vtk.js vtkSphereSource ordering

### DIFF
--- a/src/pyvista_js/mesh.py
+++ b/src/pyvista_js/mesh.py
@@ -758,18 +758,31 @@ def Sphere(  # noqa: N802
     >>> import pyvista_js as pv
     >>> sphere = pv.Sphere(radius=1.0)
     >>> sphere.n_points
-    902
+    842
 
     """
-    theta = np.linspace(0, 2 * np.pi, theta_resolution)
-    phi = np.linspace(0, np.pi, phi_resolution)
+    # Generate points matching vtk.js vtkSphereSource ordering exactly:
+    #   index 0: north pole
+    #   index 1: south pole
+    #   then theta (outer) x phi (inner) for intermediate rows
+    # phi[j] = j * pi / (phi_resolution - 1)  for j = 1 .. phi_resolution-2
+    # theta[i] = i * 2*pi / theta_resolution   for i = 0 .. theta_resolution-1
+    delta_phi = np.pi / (phi_resolution - 1)
+    delta_theta = 2.0 * np.pi / theta_resolution
 
     points = []
-    for p in phi:
-        for t in theta:
-            x = radius * np.sin(p) * np.cos(t) + center[0]
-            y = radius * np.sin(p) * np.sin(t) + center[1]
-            z = radius * np.cos(p) + center[2]
+    # North pole (index 0)
+    points.append([center[0], center[1], center[2] + radius])
+    # South pole (index 1)
+    points.append([center[0], center[1], center[2] - radius])
+    # Intermediate points: theta outer loop, phi inner loop
+    for i in range(theta_resolution):
+        theta = i * delta_theta
+        for j in range(1, phi_resolution - 1):
+            phi = j * delta_phi
+            x = radius * np.sin(phi) * np.cos(theta) + center[0]
+            y = radius * np.sin(phi) * np.sin(theta) + center[1]
+            z = radius * np.cos(phi) + center[2]
             points.append([x, y, z])
 
     def _vtk_js_source(idx: int) -> str:

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -68,7 +68,7 @@ def test_show(monkeypatch) -> None:
 @pytest.mark.parametrize(
     ("mesh_factory", "expected_n_points"),
     [
-        (lambda: Sphere(radius=2.0, center=(1, 2, 3), theta_resolution=50), 50 * 30),
+        (lambda: Sphere(radius=2.0, center=(1, 2, 3), theta_resolution=50), 2 + 50 * (30 - 2)),
         (lambda: Cube(center=(0, 0, 0), x_length=3.0, y_length=2.0, z_length=1.0), 8),
         (lambda: Cylinder(radius=1.5, height=4.0, resolution=80), 160),
     ],

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -78,7 +78,7 @@ def test_mock_create_container(caplog) -> None:
     [
         (
             lambda: Sphere(radius=2.0, center=(1, 2, 3), theta_resolution=40, phi_resolution=50),
-            40 * 50,
+            2 + 40 * (50 - 2),
         ),
         (
             lambda: Cube(center=(1, 1, 1), x_length=2.0, y_length=3.0, z_length=4.0),


### PR DESCRIPTION
## Summary

- Corrects Sphere point generation to match the exact point ordering used by vtk.js vtkSphereSource
- Point ordering must match vtk.js vtkSphereSource so that scalar arrays assigned to `mesh.point_data` map correctly to the rendered vertices
- Previously, the Python `Sphere()` generator traversed poles and rings in a different order, causing scalar values to appear on the wrong vertices when using scalar coloring

## Background

When scalar arrays are used for coloring (e.g., `plotter.add_mesh(mesh, scalars='elevation')`), each scalar value is mapped to a vertex by index. If the Python-side point ordering does not match what vtk.js vtkSphereSource generates, the scalar values are assigned to incorrect vertices, producing wrong or garbled colorings.

This fix aligns the Python Sphere point generation with the reference implementation in vtk.js `vtkSphereSource`, ensuring consistent scalar rendering.

## Test plan

- [ ] Run `uv run pytest -x -q` and verify all tests pass
- [ ] Verify that scalar arrays on a Sphere render with correct color mapping