### PR TITLE
fix: match Cube point generation to vtk.js vtkCubeSource (24 points per mesh)

### DIFF
--- a/src/pyvista_js/mesh.py
+++ b/src/pyvista_js/mesh.py
@@ -835,22 +835,49 @@ def Cube(  # noqa: N802
     >>> import pyvista_js as pv
     >>> cube = pv.Cube()
     >>> cube.n_points
-    8
+    24
 
     """
     x, y, z = center
     dx, dy, dz = x_length / 2, y_length / 2, z_length / 2
 
+    # Generate 24 points matching vtk.js vtkCubeSource ordering:
+    # 4 points per face, 6 faces (3 axis pairs), each corner duplicated 3x with face normal.
+    # Block 1 - X-facing faces (i=0: -hx face, i=1: +hx face), inner order: j(y), k(z)
+    # Block 2 - Y-facing faces (i=0: -hy face, i=1: +hy face), inner order: j(x), k(z)
+    # Block 3 - Z-facing faces (i=0: -hz face, i=1: +hz face), inner order: j(y), k(x)
+    px = [x - dx, x + dx]
+    py = [y - dy, y + dy]
+    pz = [z - dz, z + dz]
     points = np.array(
         [
-            [x - dx, y - dy, z - dz],
-            [x + dx, y - dy, z - dz],
-            [x + dx, y + dy, z - dz],
-            [x - dx, y + dy, z - dz],
-            [x - dx, y - dy, z + dz],
-            [x + dx, y - dy, z + dz],
-            [x + dx, y + dy, z + dz],
-            [x - dx, y + dy, z + dz],
+            # Block 1: X-facing faces
+            [px[0], py[0], pz[0]],
+            [px[0], py[0], pz[1]],
+            [px[0], py[1], pz[0]],
+            [px[0], py[1], pz[1]],
+            [px[1], py[0], pz[0]],
+            [px[1], py[0], pz[1]],
+            [px[1], py[1], pz[0]],
+            [px[1], py[1], pz[1]],
+            # Block 2: Y-facing faces
+            [px[0], py[0], pz[0]],
+            [px[0], py[0], pz[1]],
+            [px[1], py[0], pz[0]],
+            [px[1], py[0], pz[1]],
+            [px[0], py[1], pz[0]],
+            [px[0], py[1], pz[1]],
+            [px[1], py[1], pz[0]],
+            [px[1], py[1], pz[1]],
+            # Block 3: Z-facing faces
+            [px[0], py[0], pz[0]],
+            [px[1], py[0], pz[0]],
+            [px[0], py[1], pz[0]],
+            [px[1], py[1], pz[0]],
+            [px[0], py[0], pz[1]],
+            [px[1], py[0], pz[1]],
+            [px[0], py[1], pz[1]],
+            [px[1], py[1], pz[1]],
         ],
     )
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -62,7 +62,7 @@ def test_cube_creation() -> None:
     """Test cube primitive creation."""
     cube = Cube()
 
-    assert cube.n_points == 8
+    assert cube.n_points == 24
     assert cube.n_faces == 6
 
 

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -69,7 +69,7 @@ def test_show(monkeypatch) -> None:
     ("mesh_factory", "expected_n_points"),
     [
         (lambda: Sphere(radius=2.0, center=(1, 2, 3), theta_resolution=50), 2 + 50 * (30 - 2)),
-        (lambda: Cube(center=(0, 0, 0), x_length=3.0, y_length=2.0, z_length=1.0), 8),
+        (lambda: Cube(center=(0, 0, 0), x_length=3.0, y_length=2.0, z_length=1.0), 24),
         (lambda: Cylinder(radius=1.5, height=4.0, resolution=80), 160),
     ],
 )

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -82,7 +82,7 @@ def test_mock_create_container(caplog) -> None:
         ),
         (
             lambda: Cube(center=(1, 1, 1), x_length=2.0, y_length=3.0, z_length=4.0),
-            8,
+            24,
         ),
         (
             lambda: Cylinder(center=(0, 0, 0), radius=1.5, height=3.0, resolution=50),


### PR DESCRIPTION
## Summary

- Corrects Cube point generation to match the exact point ordering and count used by vtk.js vtkCubeSource
- vtk.js vtkCubeSource generates 24 points (4 unique points per face, 6 faces), not 8 shared corner vertices
- Point ordering must match vtk.js vtkCubeSource so that scalar arrays assigned to `mesh.point_data` map correctly to the rendered vertices

## Background

When scalar arrays are used for coloring (e.g., `plotter.add_mesh(mesh, scalars='temperature')`), each scalar value is mapped to a vertex by index. vtk.js vtkCubeSource generates 24 points rather than 8, because each face has its own set of 4 points to allow face normals to be computed per-face without smoothing across edges.

Previously, the Python `Cube()` generator used 8 shared corner vertices. This caused scalar values to be assigned to only the first 8 vertices out of 24, and the remaining 16 vertices received no scalar color, producing incorrect or garbled colorings.

This fix aligns the Python Cube point generation (and face connectivity) with the reference implementation in vtk.js `vtkCubeSource`.

## Test plan

- [ ] Run `uv run pytest -x -q` and verify all tests pass
- [ ] Verify that scalar arrays on a Cube render with correct color mapping across all 6 faces