### PR TITLE
docs: add CLI reference documentation

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -115,10 +115,4 @@ This section provides detailed documentation for the pyvista-js public API.
 
 ## CLI
 
-```{eval-rst}
-.. autosummary::
-   :toctree: _autosummary
-   :nosignatures:
-
-   pyvista_js._cli.main
-```
+See the {doc}`CLI reference </cli/index>` for command-line usage documentation.

--- a/docs/cli/capture-preview.md
+++ b/docs/cli/capture-preview.md
@@ -1,0 +1,8 @@
+# capture-preview
+
+```{eval-rst}
+.. typer:: pyvista_js._cli.app:capture-preview
+    :prog: pyvista-js capture-preview
+    :width: 75
+    :preferred: text
+```

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1,0 +1,24 @@
+# CLI
+
+Once `pyvista-js` has been installed, a console script [^1] will be available with
+several convenience commands to assist with browser-based 3-D visualization.
+
+```{eval-rst}
+.. typer:: pyvista_js._cli.app
+    :prog: pyvista-js
+    :width: 75
+    :preferred: text
+```
+
+## Commands
+
+The following `pyvista-js` console script commands are available:
+
+```{toctree}
+plot
+info
+capture-preview
+```
+
+[^1]: See [entry-points](https://setuptools.pypa.io/en/latest/userguide/entry_point.html)
+      for further information.

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -20,5 +20,5 @@ info
 capture-preview
 ```
 
-[^1]: See [entry-points](https://setuptools.pypa.io/en/latest/userguide/entry_point.html)
-      for further information.
+\[^1\]: See [entry-points](https://setuptools.pypa.io/en/latest/userguide/entry_point.html)
+for further information.

--- a/docs/cli/info.md
+++ b/docs/cli/info.md
@@ -1,0 +1,8 @@
+# info
+
+```{eval-rst}
+.. typer:: pyvista_js._cli.app:info
+    :prog: pyvista-js info
+    :width: 75
+    :preferred: text
+```

--- a/docs/cli/plot.md
+++ b/docs/cli/plot.md
@@ -1,0 +1,8 @@
+# plot
+
+```{eval-rst}
+.. typer:: pyvista_js._cli.app:plot
+    :prog: pyvista-js plot
+    :width: 75
+    :preferred: text
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
+    "sphinxcontrib.typer",
     "sphinx_design",
 ]
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,7 @@ tutorials/index
 howtos/index
 explanation/index
 api/index
+cli/index
 ```
 
 ```{toctree}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ optional-dependencies.docs = [
   "sphinx==9.1; python_version>='3.12'",
   "sphinx-book-theme==1.1.4; python_version>='3.12'",
   "sphinx-design==0.7; python_version>='3.12'",
+  "sphinxcontrib-typer>=0.5; python_version>='3.12'",
 ]
 optional-dependencies.io = [
   "meshio",


### PR DESCRIPTION
## Summary
- Add dedicated CLI documentation pages using `sphinxcontrib-typer` to auto-generate docs from the Typer app
- Create separate pages for each subcommand: `plot`, `info`, `capture-preview`
- Structure modeled after [geovista CLI reference](https://geovista.readthedocs.io/ja/latest/reference/cli/)

## Test plan
- [x] Verify `sphinxcontrib-typer` directive renders correctly in docs build
- [x] Check each subcommand page shows correct usage and options
- [x] Confirm toctree navigation works from index to subcommand pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)