### PR TITLE
feat: upload coverage for all supported Python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,8 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        # SPEC 0: Only test Python versions within 36-month support window
-        python-version: ['3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,8 +14,25 @@ comment:
   behavior: default
   require_changes: false
 
-# SPEC 0: Only test Python versions within 36-month support window
 flags:
+  py3.10-ubuntu-latest:
+    paths:
+      - src/
+  py3.10-windows-latest:
+    paths:
+      - src/
+  py3.10-macos-latest:
+    paths:
+      - src/
+  py3.11-ubuntu-latest:
+    paths:
+      - src/
+  py3.11-windows-latest:
+    paths:
+      - src/
+  py3.11-macos-latest:
+    paths:
+      - src/
   py3.12-ubuntu-latest:
     paths:
       - src/


### PR DESCRIPTION
## Summary

- Add Python 3.10 and 3.11 to the test matrix in `test.yml`
- Add corresponding flags for py3.10 and py3.11 (all OS combinations) to `codecov.yml`

This replaces the previous `claude/upload-coverage-reports` branch, which had a bad conflict resolution that accidentally reverted `pyproject.toml` from 0.8.0 to 0.7.0 and lost several changes from main (SPEC 0 updates, `sphinxcontrib-typer`, `jupytext`, etc.). This PR is rebased cleanly on main and contains only the intended coverage changes.

## Test plan

- [ ] Verify CI runs tests on Python 3.10, 3.11, 3.12, 3.13, 3.14
- [ ] Verify Codecov receives flags for all Python version / OS combinations
- [ ] Confirm no unintended changes to `pyproject.toml` or other files

🤖 Generated with [Claude Code](https://claude.com/claude-code)