### PR TITLE
fix: restrict atsphinx-stlite to python < 3.14 in docs extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ optional-dependencies.dev = [
   "tox>=4",
 ]
 optional-dependencies.docs = [
-  "atsphinx-stlite==0.2.1; python_version>='3.12'",
+  "atsphinx-stlite==0.2.1; python_version>='3.12' and python_version<'3.14'",
   "jupyterlite-pyodide-kernel==0.7.1; python_version>='3.12'",
   "jupyterlite-sphinx==0.22.1; python_version>='3.12'",
   "jupytext>=1.19",

--- a/uv.lock
+++ b/uv.lock
@@ -126,8 +126,8 @@ name = "atsphinx-stlite"
 version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jinja2" },
-    { name = "sphinx" },
+    { name = "jinja2", marker = "python_full_version < '3.14'" },
+    { name = "sphinx", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bf/1b/7517a828a9866a1b8fe4731f0f085257052ce8f7d14554639fedff0aba4a/atsphinx_stlite-0.2.1.tar.gz", hash = "sha256:6bb97303bd89fd7e99c5691397aa0a81e861ad65444ddd37efba7770d228de54", size = 87419, upload-time = "2025-12-12T15:56:08.398Z" }
 wheels = [
@@ -1518,7 +1518,7 @@ dev = [
     { name = "tox" },
 ]
 docs = [
-    { name = "atsphinx-stlite" },
+    { name = "atsphinx-stlite", marker = "python_full_version < '3.14'" },
     { name = "jupyterlite-pyodide-kernel" },
     { name = "jupyterlite-sphinx" },
     { name = "jupytext" },
@@ -1550,7 +1550,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "atsphinx-stlite", marker = "python_full_version >= '3.12' and extra == 'docs'", specifier = "==0.2.1" },
+    { name = "atsphinx-stlite", marker = "python_full_version >= '3.12' and python_full_version < '3.14' and extra == 'docs'", specifier = "==0.2.1" },
     { name = "jinja2", specifier = ">=3" },
     { name = "jupyterlite-pyodide-kernel", marker = "python_full_version >= '3.12' and extra == 'docs'", specifier = "==0.7.1" },
     { name = "jupyterlite-sphinx", marker = "python_full_version >= '3.12' and extra == 'docs'", specifier = "==0.22.1" },


### PR DESCRIPTION
## Summary

- `atsphinx-stlite==0.2.1` does not support Python 3.14, causing `uv-lock` pre-commit check to fail with a dependency resolution error in PR #239
- Add `python_version<'3.14'` marker to the `atsphinx-stlite` dependency in `[project.optional-dependencies.docs]`
- Update `uv.lock` accordingly

## Test plan

- Verify `pre-commit.ci` passes on this PR
- Confirm `uv lock` resolves successfully for all supported Python versions (3.12, 3.13, 3.14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)