### PR TITLE
fix: install lazy-loader in JupyterLite preamble to fix Try it examples

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,6 +107,7 @@ try_examples_global_warning_text = (
 try_examples_preamble = (
     "import micropip\n"
     "await micropip.install('jinja2')\n"
+    "await micropip.install('lazy-loader')\n"
     "import sys\n"
     "sys.path.insert(0, '/drive/src')\n"
     "import pyvista_js as pv\n"


### PR DESCRIPTION
## Summary

- The SPEC 0001 lazy loading change (e63dff18) added `lazy-loader` as a core dependency of `pyvista_js`
- The JupyterLite try-examples preamble in `docs/conf.py` only installed `jinja2` via `micropip`, but did not install `lazy-loader`
- When users click "Try it with JupyterLite" on the API docs, `import pyvista_js as pv` fails with `ModuleNotFoundError: lazy_loader`

## Test plan

- [x] Build the documentation and verify the "Try it with JupyterLite" button works on https://pyvista-js.readthedocs.io/en/latest/api/index.html
- [x] Click any API example and confirm `import pyvista_js as pv` succeeds in the JupyterLite kernel

🤖 Generated with [Claude Code](https://claude.com/claude-code)