### PR TITLE
fix: add iframe-height to typer directives to bypass Selenium dependency

### DIFF
--- a/docs/cli/capture-preview.md
+++ b/docs/cli/capture-preview.md
@@ -6,4 +6,5 @@
     :width: 75
     :preferred: html
     :theme: monokai
+    :iframe-height: 400
 ```

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -9,6 +9,7 @@ several convenience commands to assist with browser-based 3-D visualization.
     :width: 75
     :preferred: html
     :theme: monokai
+    :iframe-height: 400
 ```
 
 ## Commands

--- a/docs/cli/info.md
+++ b/docs/cli/info.md
@@ -6,4 +6,5 @@
     :width: 75
     :preferred: html
     :theme: monokai
+    :iframe-height: 400
 ```

--- a/docs/cli/plot.md
+++ b/docs/cli/plot.md
@@ -6,4 +6,5 @@
     :width: 75
     :preferred: html
     :theme: monokai
+    :iframe-height: 400
 ```


### PR DESCRIPTION
## Summary

- Add `:iframe-height: 400` to all `.. typer::` directives in CLI documentation files

## Problem

The ReadTheDocs build environment does not have Selenium/Chrome installed. When `sphinxcontrib-typer` uses `:preferred: html`, it calls `typer_get_iframe_height()` which requires a Selenium WebDriver to measure the rendered iframe height. Without Selenium available, the content is silently dropped and nothing is rendered on the page.

## Fix

Adding `:iframe-height: 400` to each directive bypasses the Selenium-based height detection entirely. The iframe renders at a fixed height instead, which makes the HTML content visible.

## Affected files

- `docs/cli/plot.md`
- `docs/cli/info.md`
- `docs/cli/index.md`
- `docs/cli/capture-preview.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)