### PR TITLE
feat: add transifex.yml for GitHub App integration

### DIFF
--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   transifex:
@@ -67,18 +66,3 @@ jobs:
           done
           tx push --source
 
-      - name: Pull translations from Transifex
-        env:
-          TX_TOKEN: ${{ secrets.TX_TOKEN }}
-        run: tx pull --all --force
-
-      - name: Create pull request for translations
-        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676  # v7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: 'chore: update translations from Transifex'
-          branch: chore/transifex-translations
-          base: main
-          title: 'chore: update translations from Transifex'
-          body: Automated translation update from Transifex.
-          labels: translations

--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -65,4 +65,3 @@ jobs:
               "$slug" "${rel%.pot}" "$pot" >> .tx/config
           done
           tx push --source
-

--- a/transifex.yml
+++ b/transifex.yml
@@ -1,0 +1,7 @@
+filters:
+  - filter_type: dir
+    file_format: PO
+    source_language: en
+    source_file_extension: pot
+    source_file: docs/pot/<path>.pot
+    translation_files_expression: docs/locale/<lang>/LC_MESSAGES/<path>.po


### PR DESCRIPTION
## Summary

- Add `transifex.yml` config file for the Transifex GitHub App integration
- The Transifex GitHub App (`transifex-integration[bot]`) will automatically create pull requests when translations are updated
- Remove `tx pull` and `peter-evans/create-pull-request` steps from the workflow (no longer needed)
- Remove `pull-requests: write` permission from the workflow (no longer needed)

## How it works

1. The GitHub Actions workflow generates `.pot` files and pushes source strings to Transifex
2. Translators update translations in Transifex
3. The Transifex GitHub App detects the updates and automatically opens a PR as `transifex-integration[bot]`

## Test plan

- [ ] Merge this PR
- [ ] Verify the Transifex GitHub App integration picks up the `transifex.yml` config
- [ ] Verify the next translation update creates a PR authored by `transifex-integration[bot]`