### PR TITLE
fix: replace source_file with source_file_dir in transifex.yml

### DIFF
--- a/transifex.yml
+++ b/transifex.yml
@@ -3,5 +3,5 @@ filters:
     file_format: PO
     source_language: en
     source_file_extension: pot
-    source_file: docs/pot/<path>.pot
+    source_file_dir: docs/pot
     translation_files_expression: docs/locale/<lang>/LC_MESSAGES/<path>.po


### PR DESCRIPTION
## Summary

- Fix Transifex configuration error: `source_file` is an unknown field for `filter_type: dir`
- Replace `source_file` with `source_file_dir` as required by the Transifex GitHub App

## Test plan

- [ ] Verify Transifex GitHub App loads `transifex.yml` without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)