### PR TITLE
fix: remove unsupported <path> placeholder from translation_files_expression

### DIFF
--- a/transifex.yml
+++ b/transifex.yml
@@ -3,5 +3,5 @@ filters:
     file_format: PO
     source_language: en
     source_file_extension: pot
-    source_file: docs/pot/<path>.pot
-    translation_files_expression: docs/locale/<lang>/LC_MESSAGES/<path>.po
+    source_file_dir: docs/pot
+    translation_files_expression: 'docs/locale/<lang>/LC_MESSAGES'


### PR DESCRIPTION
## Summary

- `filter_type: dir` only supports `<lang>` as a placeholder in `translation_files_expression`
- Remove `<path>.po` suffix — the directory structure under `source_file_dir` is mirrored automatically
- Fixes the strange path `docs/locale/ja/LC_MESSAGES/<path>.po/cli/plot.po`

## Test plan

- [ ] Verify Transifex GitHub App resolves translation paths correctly (e.g. `docs/locale/ja/LC_MESSAGES/cli/plot.po`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)