### PR TITLE
docs: move badges from README.md to corresponding sections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,7 @@ git commit -m "feat(plotter): add support for physically based rendering"
 
 ## Code Quality Standards
 
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![djlint](https://img.shields.io/badge/html%20templates-djLint-blueviolet.svg)](https://www.djlint.com)
 
 ### Pre-commit Hooks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,8 @@ pyvista-js is a PyVista-like API for vtk.js that brings intuitive 3D visualizati
 
 ## Development Workflow
 
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
+
 ### Creating a Branch
 
 Create a descriptive branch name:
@@ -124,6 +126,8 @@ git commit -m "feat(plotter): add support for physically based rendering"
 ```
 
 ## Code Quality Standards
+
+[![djlint](https://img.shields.io/badge/html%20templates-djLint-blueviolet.svg)](https://www.djlint.com)
 
 ### Pre-commit Hooks
 
@@ -193,6 +197,8 @@ uv run pytest --cov=pyvista_js --cov-report=html
 - Tests should pass on Python 3.12, 3.13, and 3.14
 
 ## Documentation
+
+[![Diátaxis](https://img.shields.io/badge/Documentation-Di%C3%A1taxis-blue.svg?style=flat)](https://diataxis.fr/)
 
 ### Documentation Framework
 
@@ -307,26 +313,36 @@ This project follows several [Scientific Python SPECs](https://scientific-python
 
 ### SPEC 0 — Minimum Supported Dependencies
 
+[![SPEC 0 — Minimum Supported Dependencies](https://img.shields.io/badge/SPEC-0-green?labelColor=%23004811&color=%235CA038)](https://scientific-python.org/specs/spec-0000/)
+
 - **Python**: 3.12+ (drop support 36 months after release)
 - **NumPy**: 2.0+ (drop support 24 months after release)
 - Other core dependencies follow similar policies
 
 ### SPEC 1 — Lazy Loading of Submodules
 
+[![SPEC 1 — Lazy Loading of Submodules and Functions](https://img.shields.io/badge/SPEC-1-green?labelColor=%23004811&color=%235CA038)](https://scientific-python.org/specs/spec-0001/)
+
 - Submodules are lazily loaded using `lazy-loader`
 - Improves import time and memory usage
 
 ### SPEC 4 — Nightly Tests
+
+[![SPEC 4 — Nightly Tests](https://img.shields.io/badge/SPEC-4-green?labelColor=%23004811&color=%235CA038)](https://scientific-python.org/specs/spec-0004/)
 
 - Regular testing against development versions of dependencies
 - Ensures forward compatibility
 
 ### SPEC 6 — Upper Bound Constraints
 
+[![SPEC 6 — Upper Bound Constraints on Dependencies](https://img.shields.io/badge/SPEC-6-green?labelColor=%23004811&color=%235CA038)](https://scientific-python.org/specs/spec-0006/)
+
 - No upper bounds on dependency versions unless technically required
 - Prevents dependency conflicts in downstream projects
 
 ### SPEC 7 — Seeding Random Number Generation
+
+[![SPEC 7 — Seeding Pseudo-Random Number Generation](https://img.shields.io/badge/SPEC-7-green?labelColor=%23004811&color=%235CA038)](https://scientific-python.org/specs/spec-0007/)
 
 - Use `numpy.random.default_rng()` for random number generation
 - Use `rng` parameter for seeding
@@ -339,6 +355,9 @@ This project follows several [Scientific Python SPECs](https://scientific-python
 - All GitHub Actions pinned to commit SHAs
 
 ## Community Resources
+
+[![Transifex](https://img.shields.io/badge/Translations-Transifex-blue.svg)](https://app.transifex.com/tkoyama010/pyvista-js/)
+[![Join the community](https://img.shields.io/badge/Join%20the%20community-on%20GitHub%20Discussions-blue)](https://github.com/tkoyama010/pyvista-js/discussions)
 
 - **Issues**: [GitHub Issues](https://github.com/tkoyama010/pyvista-js/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/tkoyama010/pyvista-js/discussions)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,7 @@ git commit -m "feat(plotter): add support for physically based rendering"
 
 ## Code Quality Standards
 
+[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![djlint](https://img.shields.io/badge/html%20templates-djLint-blueviolet.svg)](https://www.djlint.com)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,6 @@ git commit -m "feat(plotter): add support for physically based rendering"
 
 ## Code Quality Standards
 
-[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![djlint](https://img.shields.io/badge/html%20templates-djLint-blueviolet.svg)](https://www.djlint.com)
 
@@ -164,6 +163,8 @@ uv run mypy src/
 - **Imports**: Organize imports logically; pre-commit will sort them
 
 ## Testing
+
+[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 
 ### Running Tests
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # pyvista-js
 
-[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Documentation Status](https://readthedocs.org/projects/pyvista-js/badge/?version=latest)](https://pyvista-js.readthedocs.io/en/latest/?badge=latest)
 [![JupyterLite](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://tkoyama010.github.io/pyvista-js/)
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg)](https://github.com/RichardLitt/standard-readme)
@@ -109,5 +108,7 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 ## License
+
+[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
 [BSD 3-Clause](LICENSE) © Tetsuo Koyama

--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@
 [![Documentation Status](https://readthedocs.org/projects/pyvista-js/badge/?version=latest)](https://pyvista-js.readthedocs.io/en/latest/?badge=latest)
 [![JupyterLite](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://tkoyama010.github.io/pyvista-js/)
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg)](https://github.com/RichardLitt/standard-readme)
-[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
-[![djlint](https://img.shields.io/badge/html%20templates-djLint-blueviolet.svg)](https://www.djlint.com)
-[![zizmor](https://img.shields.io/badge/%F0%9F%8C%88-zizmor-white?labelColor=white)](https://zizmor.sh/)
-[![Diátaxis](https://img.shields.io/badge/Documentation-Di%C3%A1taxis-blue.svg?style=flat)](https://diataxis.fr/)
 
 [PyVista](https://github.com/pyvista/pyvista)-like API for [vtk.js](https://github.com/Kitware/vtk-js) — bring intuitive 3D visualization to the browser.
 
@@ -53,11 +49,6 @@ plotter.show()
 ## Citation
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19092335.svg)](https://doi.org/10.5281/zenodo.19092335)
-[![SPEC 0 — Minimum Supported Dependencies](https://img.shields.io/badge/SPEC-0-green?labelColor=%23004811&color=%235CA038)](https://scientific-python.org/specs/spec-0000/)
-[![SPEC 1 — Lazy Loading of Submodules and Functions](https://img.shields.io/badge/SPEC-1-green?labelColor=%23004811&color=%235CA038)](https://scientific-python.org/specs/spec-0001/)
-[![SPEC 4 — Nightly Tests](https://img.shields.io/badge/SPEC-4-green?labelColor=%23004811&color=%235CA038)](https://scientific-python.org/specs/spec-0004/)
-[![SPEC 6 — Upper Bound Constraints on Dependencies](https://img.shields.io/badge/SPEC-6-green?labelColor=%23004811&color=%235CA038)](https://scientific-python.org/specs/spec-0006/)
-[![SPEC 7 — Seeding Pseudo-Random Number Generation](https://img.shields.io/badge/SPEC-7-green?labelColor=%23004811&color=%235CA038)](https://scientific-python.org/specs/spec-0007/)
 
 If you use pyvista-js in your research or projects, please cite it using the following:
 
@@ -77,8 +68,6 @@ Alternatively, you can use the [CITATION.cff](CITATION.cff) file in this reposit
 ## Contributing
 
 ![All Contributors](https://img.shields.io/github/all-contributors/tkoyama010/pyvista-js?color=ee8449)
-[![Transifex](https://img.shields.io/badge/Translations-Transifex-blue.svg)](https://app.transifex.com/tkoyama010/pyvista-js/)
-[![Join the community](https://img.shields.io/badge/Join%20the%20community-on%20GitHub%20Discussions-blue)](https://github.com/tkoyama010/pyvista-js/discussions)
 [![codecov](https://codecov.io/gh/tkoyama010/pyvista-js/branch/main/graph/badge.svg)](https://codecov.io/gh/tkoyama010/pyvista-js)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/tkoyama010/pyvista-js/main.svg)](https://results.pre-commit.ci/latest/github/tkoyama010/pyvista-js/main)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,7 @@
 # Security Policy
 
 [![SPEC 8 — Securing the Release Process](https://img.shields.io/badge/SPEC-8-green?labelColor=%23004811&color=%235CA038)](https://scientific-python.org/specs/spec-0008/)
+[![zizmor](https://img.shields.io/badge/%F0%9F%8C%88-zizmor-white?labelColor=white)](https://zizmor.sh/)
 
 ## Supported Versions
 


### PR DESCRIPTION
## Summary

- Remove badges from README.md that have corresponding sections in CONTRIBUTING.md
- Add each badge to its relevant CONTRIBUTING.md section (Development Workflow, Code Quality Standards, Documentation, Scientific Python Standards, Community Resources)
- Move zizmor badge from README.md to SECURITY.md

## Badges moved

| Badge | From | To |
|-------|------|----|
| Conventional Commits | README.md top | CONTRIBUTING.md#development-workflow |
| djlint | README.md top | CONTRIBUTING.md#code-quality-standards |
| Diátaxis | README.md top | CONTRIBUTING.md#documentation |
| SPEC 0/1/4/6/7 | README.md Citation section | CONTRIBUTING.md respective SPEC sub-sections |
| Transifex | README.md Contributing section | CONTRIBUTING.md#community-resources |
| Join the community | README.md Contributing section | CONTRIBUTING.md#community-resources |
| zizmor | README.md top | SECURITY.md |

## Test plan

- [x] Verify README.md renders correctly on GitHub
- [x] Verify CONTRIBUTING.md section badges are visible and link correctly
- [x] Verify SECURITY.md zizmor badge appears correctly