### PR TITLE
refactor: split camera_position setter to remove C901/PLR0912 noqa

### DIFF
--- a/src/pyvista_js/plotter.py
+++ b/src/pyvista_js/plotter.py
@@ -865,6 +865,59 @@ class Plotter:
             )
         return None
 
+    @camera_position.setter
+    def camera_position(
+        self,
+        cpos: str
+        | tuple[float, float, float]
+        | tuple[
+            tuple[float, float, float],
+            tuple[float, float, float],
+            tuple[float, float, float],
+        ]
+        | list[float]
+        | list[tuple[float, float, float]]
+        | list[list[float]],
+    ) -> None:
+        """Set the camera position.
+
+        Parameters
+        ----------
+        cpos : str, tuple, or list
+            Camera position specification. Can be:
+
+            - String shortcut: 'xy', 'xz', 'yz', 'yx', 'zx', 'zy', or 'iso'
+            - Direction vector: 3-element tuple/list (x, y, z)
+            - Full camera spec: 3-tuple/list of 3-tuples/lists:
+              [(position), (focal_point), (view_up)]
+
+        Examples
+        --------
+        Using string shortcuts:
+
+        >>> plotter = pv.Plotter()
+        >>> plotter.camera_position = 'xy'
+        >>> plotter.camera_position = 'iso'
+
+        Using direction vector:
+
+        >>> plotter = pv.Plotter()
+        >>> plotter.camera_position = (1, 0, 0)
+
+        Using full camera specification:
+
+        >>> plotter = pv.Plotter()
+        >>> plotter.camera_position = [(2.0, 5.0, 13.0), (0.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
+
+        """
+        if isinstance(cpos, str):
+            self._set_camera_position_from_str(cpos)
+        elif isinstance(cpos, (tuple, list)):
+            self._set_camera_position_from_sequence(cpos)
+        else:
+            msg = f"Invalid camera position type: {type(cpos)}. Expected string, tuple, or list"  # type: ignore[unreachable]
+            raise TypeError(msg)
+
     #: Maps camera position string shortcuts to the corresponding view method name.
     _CAMERA_POSITION_SHORTCUTS: ClassVar[dict[str, str]] = {
         "xy": "view_xy",
@@ -926,59 +979,6 @@ class Plotter:
             "3-element direction vector or 3x3 camera specification"
         )
         raise ValueError(msg)
-
-    @camera_position.setter
-    def camera_position(
-        self,
-        cpos: str
-        | tuple[float, float, float]
-        | tuple[
-            tuple[float, float, float],
-            tuple[float, float, float],
-            tuple[float, float, float],
-        ]
-        | list[float]
-        | list[tuple[float, float, float]]
-        | list[list[float]],
-    ) -> None:
-        """Set the camera position.
-
-        Parameters
-        ----------
-        cpos : str, tuple, or list
-            Camera position specification. Can be:
-
-            - String shortcut: 'xy', 'xz', 'yz', 'yx', 'zx', 'zy', or 'iso'
-            - Direction vector: 3-element tuple/list (x, y, z)
-            - Full camera spec: 3-tuple/list of 3-tuples/lists:
-              [(position), (focal_point), (view_up)]
-
-        Examples
-        --------
-        Using string shortcuts:
-
-        >>> plotter = pv.Plotter()
-        >>> plotter.camera_position = 'xy'
-        >>> plotter.camera_position = 'iso'
-
-        Using direction vector:
-
-        >>> plotter = pv.Plotter()
-        >>> plotter.camera_position = (1, 0, 0)
-
-        Using full camera specification:
-
-        >>> plotter = pv.Plotter()
-        >>> plotter.camera_position = [(2.0, 5.0, 13.0), (0.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
-
-        """
-        if isinstance(cpos, str):
-            self._set_camera_position_from_str(cpos)
-        elif isinstance(cpos, (tuple, list)):
-            self._set_camera_position_from_sequence(cpos)
-        else:
-            msg = f"Invalid camera position type: {type(cpos)}. Expected string, tuple, or list"  # type: ignore[unreachable]
-            raise TypeError(msg)
 
     @property
     def background_color(self) -> tuple[float, float, float]:

--- a/src/pyvista_js/plotter.py
+++ b/src/pyvista_js/plotter.py
@@ -7,7 +7,7 @@ using vtk.js in browser environments.
 from __future__ import annotations
 
 import uuid
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from .rendering import get_renderer
 
@@ -865,8 +865,70 @@ class Plotter:
             )
         return None
 
+    #: Maps camera position string shortcuts to the corresponding view method name.
+    _CAMERA_POSITION_SHORTCUTS: ClassVar[dict[str, str]] = {
+        "xy": "view_xy",
+        "xz": "view_xz",
+        "yz": "view_yz",
+        "yx": "view_yx",
+        "zx": "view_zx",
+        "zy": "view_zy",
+        "iso": "view_isometric",
+    }
+
+    def _set_camera_position_from_str(self, cpos: str) -> None:
+        """Set camera position from a string shortcut."""
+        key = cpos.lower()
+        method = self._CAMERA_POSITION_SHORTCUTS.get(key)
+        if method is None:
+            msg = (
+                f"Unknown camera position string: '{cpos}'. "
+                "Supported: 'xy', 'xz', 'yz', 'yx', 'zx', 'zy', 'iso'"
+            )
+            raise ValueError(msg)
+        getattr(self, method)()
+
+    def _set_camera_position_from_sequence(
+        self,
+        cpos: tuple[float, float, float]
+        | tuple[
+            tuple[float, float, float],
+            tuple[float, float, float],
+            tuple[float, float, float],
+        ]
+        | list[float]
+        | list[tuple[float, float, float]]
+        | list[list[float]],
+    ) -> None:
+        """Set camera position from a tuple or list."""
+        vector_length = 3
+        if len(cpos) == vector_length and all(isinstance(x, (int, float)) for x in cpos):
+            self.view_vector((float(cpos[0]), float(cpos[1]), float(cpos[2])))  # type: ignore[arg-type]
+            return
+
+        if len(cpos) == vector_length and all(
+            isinstance(item, (tuple, list))
+            and len(item) == vector_length
+            and all(isinstance(x, (int, float)) for x in item)
+            for item in cpos
+        ):
+            from .camera import Camera  # noqa: PLC0415
+
+            self.camera = Camera(
+                position=(float(cpos[0][0]), float(cpos[0][1]), float(cpos[0][2])),  # type: ignore[index]
+                focal_point=(float(cpos[1][0]), float(cpos[1][1]), float(cpos[1][2])),  # type: ignore[index]
+                view_up=(float(cpos[2][0]), float(cpos[2][1]), float(cpos[2][2])),  # type: ignore[index]
+            )
+            return
+
+        msg = (
+            "Invalid camera position format. Expected: "
+            "3-element direction vector or 3x3 camera specification"
+        )
+        raise ValueError(msg)
+
     @camera_position.setter
-    def camera_position(  # noqa: C901
+    def camera_position(
         self,
         cpos: str
         | tuple[float, float, float]
@@ -910,71 +972,13 @@ class Plotter:
         >>> plotter.camera_position = [(2.0, 5.0, 13.0), (0.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
 
         """
-        # Handle string shortcuts
         if isinstance(cpos, str):
-            cpos_lower = cpos.lower()
-            if cpos_lower == "xy":
-                self.view_xy()
-            elif cpos_lower == "xz":
-                self.view_xz()
-            elif cpos_lower == "yz":
-                self.view_yz()
-            elif cpos_lower == "yx":
-                self.view_yx()
-            elif cpos_lower == "zx":
-                self.view_zx()
-            elif cpos_lower == "zy":
-                self.view_zy()
-            elif cpos_lower == "iso":
-                self.view_isometric()
-            else:
-                msg = (
-                    f"Unknown camera position string: '{cpos}'. "
-                    "Supported: 'xy', 'xz', 'yz', 'yx', 'zx', 'zy', 'iso'"
-                )
-                raise ValueError(msg)
-            return
-
-        # Handle tuple/list input
-        if isinstance(cpos, (tuple, list)):
-            vector_length = 3
-            # Check if it's a direction vector (3 numbers)
-            if len(cpos) == vector_length and all(isinstance(x, (int, float)) for x in cpos):
-                # Direction vector
-                self.view_vector((float(cpos[0]), float(cpos[1]), float(cpos[2])))  # type: ignore[arg-type]
-                return
-
-            # Check if it's full camera specification (3 tuples/lists of 3 numbers each)
-            if len(cpos) == vector_length and all(
-                isinstance(item, (tuple, list))
-                and len(item) == vector_length
-                and all(isinstance(x, (int, float)) for x in item)
-                for item in cpos
-            ):
-                # Full camera specification
-                position = (float(cpos[0][0]), float(cpos[0][1]), float(cpos[0][2]))  # type: ignore[index]
-                focal_point = (float(cpos[1][0]), float(cpos[1][1]), float(cpos[1][2]))  # type: ignore[index]
-                view_up = (float(cpos[2][0]), float(cpos[2][1]), float(cpos[2][2]))  # type: ignore[index]
-
-                # Import Camera here to avoid circular imports
-                from .camera import Camera  # noqa: PLC0415
-
-                camera = Camera(
-                    position=position,
-                    focal_point=focal_point,
-                    view_up=view_up,
-                )
-                self.camera = camera
-                return
-
-            msg = (
-                "Invalid camera position format. Expected: "
-                "3-element direction vector or 3x3 camera specification"
-            )
-            raise ValueError(msg)
-
-        msg = f"Invalid camera position type: {type(cpos)}. Expected string, tuple, or list"  # type: ignore[unreachable]
-        raise TypeError(msg)
+            self._set_camera_position_from_str(cpos)
+        elif isinstance(cpos, (tuple, list)):
+            self._set_camera_position_from_sequence(cpos)
+        else:
+            msg = f"Invalid camera position type: {type(cpos)}. Expected string, tuple, or list"  # type: ignore[unreachable]
+            raise TypeError(msg)
 
     @property
     def background_color(self) -> tuple[float, float, float]:


### PR DESCRIPTION
## Summary

- Extract `_set_camera_position_from_str` to handle string shortcut dispatch via a `ClassVar` dict, eliminating the `if/elif` chain
- Extract `_set_camera_position_from_sequence` to handle tuple/list input
- Remove `# noqa: C901` from `camera_position` setter — now compliant with C901 and PLR0912

## Test plan

- [x] Run `tox -e lint` to confirm no C901/PLR0912 violations
- [x] Run `tox -e test` to confirm existing tests still pass

Generated with [Claude Code](https://claude.com/claude-code)