### PR TITLE
fix: search iframes for canvas in stlite demo capture

### DIFF
--- a/src/pyvista_js/_cli.py
+++ b/src/pyvista_js/_cli.py
@@ -353,19 +353,18 @@ def _find_canvas_in_frames(page) -> tuple:  # noqa: ANN001
             if canvas is not None:
                 return frame, canvas
         except Exception:  # noqa: BLE001
+            logger.debug("Failed to query canvas in frame", exc_info=True)
             continue
     return None, None
 
 
-def _rotate_canvas_with_mouse(page, canvas_selector: str = "canvas") -> None:  # noqa: ANN001
+def _rotate_canvas_with_mouse(page) -> None:  # noqa: ANN001
     """Rotate the 3D model by dragging the mouse across the canvas.
 
     Parameters
     ----------
     page : playwright.sync_api.Page
         The Playwright page object.
-    canvas_selector : str
-        CSS selector for the canvas element. Default: "canvas".
 
     """
     try:
@@ -593,6 +592,36 @@ def capture_preview(
     logger.info("Preview GIF saved to: %s", output_path)
 
 
+def _wait_for_canvas_in_frames(page, timeout: int = 120) -> None:  # noqa: ANN001
+    """Poll all frames until a canvas element appears or *timeout* seconds elapse.
+
+    Parameters
+    ----------
+    page : playwright.sync_api.Page
+        The Playwright page object.
+    timeout : int
+        Maximum seconds to wait.  Default: 120.
+
+    Raises
+    ------
+    TimeoutError
+        If no canvas is found within *timeout* seconds.
+
+    """
+    import time  # noqa: PLC0415
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        _frame, canvas = _find_canvas_in_frames(page)
+        if canvas is not None:
+            logger.info("Found canvas element in iframe")
+            return
+        page.wait_for_timeout(2000)
+
+    msg = f"Canvas element not found in any frame within {timeout} seconds"
+    raise TimeoutError(msg)
+
+
 def _capture_stlite_screenshots(output_dir: Path, demo_url: str, *, rotate: bool = True) -> Path:
     """Capture screenshots from the stlite demo using Playwright.
 
@@ -639,21 +668,7 @@ def _capture_stlite_screenshots(output_dir: Path, demo_url: str, *, rotate: bool
             # components.html() creates another nested iframe for the
             # Three.js canvas.  page.wait_for_selector only searches the
             # top-level document, so we poll all frames instead.
-            import time  # noqa: PLC0415
-
-            deadline = time.monotonic() + 120
-            canvas_found = False
-            while time.monotonic() < deadline:
-                _frame, canvas = _find_canvas_in_frames(page)
-                if canvas is not None:
-                    canvas_found = True
-                    logger.info("Found canvas element in iframe")
-                    break
-                page.wait_for_timeout(2000)
-
-            if not canvas_found:
-                msg = "Canvas element not found in any frame within 120 seconds"
-                raise TimeoutError(msg)
+            _wait_for_canvas_in_frames(page)
 
             page.wait_for_timeout(5000)
 

--- a/src/pyvista_js/_cli.py
+++ b/src/pyvista_js/_cli.py
@@ -333,6 +333,30 @@ def _run_notebook_cells(page) -> None:  # noqa: ANN001
         page.keyboard.press("Shift+Enter")
 
 
+def _find_canvas_in_frames(page) -> tuple:  # noqa: ANN001
+    """Find a canvas element by searching through all frames (including nested iframes).
+
+    Parameters
+    ----------
+    page : playwright.sync_api.Page
+        The Playwright page object.
+
+    Returns
+    -------
+    tuple
+        A (frame, element_handle) pair, or (None, None) if not found.
+
+    """
+    for frame in page.frames:
+        try:
+            canvas = frame.query_selector("canvas")
+            if canvas is not None:
+                return frame, canvas
+        except Exception:  # noqa: BLE001
+            continue
+    return None, None
+
+
 def _rotate_canvas_with_mouse(page, canvas_selector: str = "canvas") -> None:  # noqa: ANN001
     """Rotate the 3D model by dragging the mouse across the canvas.
 
@@ -345,9 +369,9 @@ def _rotate_canvas_with_mouse(page, canvas_selector: str = "canvas") -> None:  #
 
     """
     try:
-        canvas = page.query_selector(canvas_selector)
+        _frame, canvas = _find_canvas_in_frames(page)
         if canvas is None:
-            logger.warning("Canvas element not found, skipping rotation")
+            logger.warning("Canvas element not found in any frame, skipping rotation")
             return
 
         box = canvas.bounding_box()
@@ -607,12 +631,30 @@ def _capture_stlite_screenshots(output_dir: Path, demo_url: str, *, rotate: bool
             page.goto(demo_url, wait_until="networkidle", timeout=120000)
 
             logger.info("Waiting for stlite to load and install dependencies...")
-            # Wait longer for stlite to initialize Python and install pyvista-js
+            # Wait for stlite to initialize Python and install pyvista-js
             page.wait_for_timeout(60000)
 
-            logger.info("Waiting for 3D rendering to appear...")
-            # Increased timeout to 120 seconds for canvas to appear
-            page.wait_for_selector("canvas", timeout=120000)
+            logger.info("Waiting for 3D rendering to appear in iframes...")
+            # stlite renders the Streamlit app in iframes, and
+            # components.html() creates another nested iframe for the
+            # Three.js canvas.  page.wait_for_selector only searches the
+            # top-level document, so we poll all frames instead.
+            import time  # noqa: PLC0415
+
+            deadline = time.monotonic() + 120
+            canvas_found = False
+            while time.monotonic() < deadline:
+                _frame, canvas = _find_canvas_in_frames(page)
+                if canvas is not None:
+                    canvas_found = True
+                    logger.info("Found canvas element in iframe")
+                    break
+                page.wait_for_timeout(2000)
+
+            if not canvas_found:
+                msg = "Canvas element not found in any frame within 120 seconds"
+                raise TimeoutError(msg)
+
             page.wait_for_timeout(5000)
 
             if rotate:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ from pyvista_js._cli import (
     _capture_stlite_screenshots,
     _find_canvas_in_frames,
     _rotate_canvas_with_mouse,
+    _wait_for_canvas_in_frames,
     capture_preview,
     capture_stlite_preview,
     cli_main,
@@ -167,6 +168,45 @@ def test_find_canvas_in_frames_returns_none_when_no_canvas() -> None:
 
     assert found_frame is None
     assert found_canvas is None
+
+
+def test_find_canvas_in_frames_skips_frames_that_raise() -> None:
+    """``_find_canvas_in_frames`` skips frames that raise and continues searching."""
+    bad_frame = MagicMock()
+    bad_frame.query_selector.side_effect = Exception("detached")
+    canvas = MagicMock()
+    good_frame = MagicMock()
+    good_frame.query_selector.return_value = canvas
+    page = MagicMock()
+    page.frames = [bad_frame, good_frame]
+
+    found_frame, found_canvas = _find_canvas_in_frames(page)
+
+    assert found_frame is good_frame
+    assert found_canvas is canvas
+
+
+def test_wait_for_canvas_in_frames_succeeds() -> None:
+    """``_wait_for_canvas_in_frames`` returns when canvas is found."""
+    canvas = MagicMock()
+    frame = MagicMock()
+    frame.query_selector.return_value = canvas
+    page = MagicMock()
+    page.frames = [frame]
+
+    # Should not raise
+    _wait_for_canvas_in_frames(page, timeout=5)
+
+
+def test_wait_for_canvas_in_frames_raises_on_timeout() -> None:
+    """``_wait_for_canvas_in_frames`` raises TimeoutError when canvas is not found."""
+    frame = MagicMock()
+    frame.query_selector.return_value = None
+    page = MagicMock()
+    page.frames = [frame]
+
+    with pytest.raises(TimeoutError, match="Canvas element not found"):
+        _wait_for_canvas_in_frames(page, timeout=0)
 
 
 def test_rotate_canvas_with_mouse_performs_drag() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ import pytest
 import pyvista_js as pv
 from pyvista_js._cli import (
     _capture_stlite_screenshots,
+    _find_canvas_in_frames,
     _rotate_canvas_with_mouse,
     capture_preview,
     capture_stlite_preview,
@@ -141,16 +142,44 @@ def test_plot_with_pickle_multiple_meshes(tmp_path) -> None:
     assert len(plotter.actors) == 2
 
 
+def test_find_canvas_in_frames_finds_canvas() -> None:
+    """``_find_canvas_in_frames`` returns frame and canvas from nested iframes."""
+    canvas = MagicMock()
+    frame = MagicMock()
+    frame.query_selector.return_value = canvas
+    page = MagicMock()
+    page.frames = [frame]
+
+    found_frame, found_canvas = _find_canvas_in_frames(page)
+
+    assert found_frame is frame
+    assert found_canvas is canvas
+
+
+def test_find_canvas_in_frames_returns_none_when_no_canvas() -> None:
+    """``_find_canvas_in_frames`` returns (None, None) when no canvas exists."""
+    frame = MagicMock()
+    frame.query_selector.return_value = None
+    page = MagicMock()
+    page.frames = [frame]
+
+    found_frame, found_canvas = _find_canvas_in_frames(page)
+
+    assert found_frame is None
+    assert found_canvas is None
+
+
 def test_rotate_canvas_with_mouse_performs_drag() -> None:
     """``_rotate_canvas_with_mouse`` performs mouse drag on canvas."""
-    page = MagicMock()
     canvas = MagicMock()
     canvas.bounding_box.return_value = {"x": 100, "y": 100, "width": 600, "height": 400}
-    page.query_selector.return_value = canvas
+    frame = MagicMock()
+    frame.query_selector.return_value = canvas
+    page = MagicMock()
+    page.frames = [frame]
 
     _rotate_canvas_with_mouse(page)
 
-    page.query_selector.assert_called_once_with("canvas")
     canvas.bounding_box.assert_called_once()
     page.mouse.move.assert_called()
     page.mouse.down.assert_called_once()
@@ -159,25 +188,27 @@ def test_rotate_canvas_with_mouse_performs_drag() -> None:
 
 def test_rotate_canvas_with_mouse_handles_missing_canvas() -> None:
     """``_rotate_canvas_with_mouse`` handles gracefully when canvas is not found."""
+    frame = MagicMock()
+    frame.query_selector.return_value = None
     page = MagicMock()
-    page.query_selector.return_value = None
+    page.frames = [frame]
 
     _rotate_canvas_with_mouse(page)
 
-    page.query_selector.assert_called_once_with("canvas")
     page.mouse.move.assert_not_called()
 
 
 def test_rotate_canvas_with_mouse_handles_missing_bounding_box() -> None:
     """``_rotate_canvas_with_mouse`` handles gracefully when bounding box is unavailable."""
-    page = MagicMock()
     canvas = MagicMock()
     canvas.bounding_box.return_value = None
-    page.query_selector.return_value = canvas
+    frame = MagicMock()
+    frame.query_selector.return_value = canvas
+    page = MagicMock()
+    page.frames = [frame]
 
     _rotate_canvas_with_mouse(page)
 
-    page.query_selector.assert_called_once_with("canvas")
     canvas.bounding_box.assert_called_once()
     page.mouse.move.assert_not_called()
 
@@ -338,7 +369,13 @@ def test_capture_stlite_preview_with_no_rotate(tmp_path) -> None:
 
 def _make_mock_playwright():
     """Create mock Playwright objects for testing screenshot capture."""
+    mock_canvas = MagicMock()
+    mock_canvas.bounding_box.return_value = {"x": 100, "y": 100, "width": 600, "height": 400}
+    mock_frame = MagicMock()
+    mock_frame.query_selector.return_value = mock_canvas
     mock_page = MagicMock()
+    # page.frames returns all frames including nested iframes
+    mock_page.frames = [mock_frame]
     mock_context = MagicMock()
     mock_context.new_page.return_value = mock_page
     mock_browser = MagicMock()


### PR DESCRIPTION
## Summary
- stlite renders the Streamlit app inside iframes, and `components.html()` places the Three.js canvas in another nested iframe
- `page.wait_for_selector("canvas")` only searches the top-level document, so the canvas was never found, causing repeated timeouts regardless of how long the timeout was set
- Add `_find_canvas_in_frames()` that iterates `page.frames` to locate the canvas in any nested iframe

## Test plan
- [x] All 32 existing tests pass
- [x] 2 new tests added for `_find_canvas_in_frames`
- [x] `_rotate_canvas_with_mouse` tests updated for iframe-aware search
- [ ] Verify update-stlite-preview workflow succeeds in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)