### PR TITLE
refactor: make generate_standalone_html public API

### DIFF
--- a/src/pyvista_js/plotter.py
+++ b/src/pyvista_js/plotter.py
@@ -398,6 +398,26 @@ class Plotter:
         # Render the scene
         self._renderer.render()
 
+    def generate_standalone_html(self) -> str:
+        """Generate a complete standalone HTML page with the current scene.
+
+        Returns
+        -------
+        str
+            A full HTML document string containing the visualization.
+
+        Examples
+        --------
+        >>> import pyvista_js as pv
+        >>> plotter = pv.Plotter()
+        >>> _ = plotter.add_mesh(pv.Sphere())
+        >>> html = plotter.generate_standalone_html()
+        >>> '<!DOCTYPE html>' in html
+        True
+
+        """
+        return self._renderer.generate_standalone_html()
+
     def view_vector(
         self,
         vector: tuple[float, float, float],

--- a/src/pyvista_js/rendering.py
+++ b/src/pyvista_js/rendering.py
@@ -774,7 +774,7 @@ class _BaseHTMLRenderer:
             RENDERER_JS=_RENDERER_JS,
         )
 
-    def _generate_standalone_html(self) -> str:
+    def generate_standalone_html(self) -> str:
         """Generate a complete standalone HTML page with vtk.js.
 
         Wraps the HTML fragment from _generate_html() in a full HTML document.
@@ -1080,7 +1080,7 @@ class BrowserRenderer(_BaseHTMLRenderer):
 
     def render(self) -> None:
         """Write the visualization to a temp HTML file and open it in the browser."""
-        html = self._generate_standalone_html()
+        html = self.generate_standalone_html()
         with tempfile.NamedTemporaryFile(
             suffix=".html",
             delete=False,
@@ -1094,7 +1094,7 @@ class BrowserRenderer(_BaseHTMLRenderer):
         webbrowser.open(url)
         logger.info("Opened visualization in browser: %s", url)
 
-    def _generate_standalone_html(self) -> str:
+    def generate_standalone_html(self) -> str:
         """Wrap the HTML fragment in a complete standalone HTML page."""
         fragment = self._generate_html()
         container_id = self.container_id
@@ -1162,7 +1162,7 @@ class BrowserRenderer(_BaseHTMLRenderer):
 
         try:
             # Generate HTML
-            html = self._generate_standalone_html()
+            html = self.generate_standalone_html()
 
             # Create temp HTML file
             with tempfile.NamedTemporaryFile(

--- a/src/pyvista_js/rendering.py
+++ b/src/pyvista_js/rendering.py
@@ -1430,6 +1430,23 @@ class MockRenderer:
         """
         logger.info("Rendering %d actors", len(self.actors))
 
+    def generate_standalone_html(self) -> str:
+        """Return a minimal HTML string for mock rendering.
+
+        Returns
+        -------
+        str
+            A placeholder HTML document.
+
+        """
+        return (
+            "<!DOCTYPE html>\n"
+            "<html>\n"
+            "<head><meta charset='utf-8'></head>\n"
+            "<body><!-- mock renderer --></body>\n"
+            "</html>\n"
+        )
+
     def add_light(self, light: Light) -> None:
         """Mock add_light.
 

--- a/tests/test_browser_rendering.py
+++ b/tests/test_browser_rendering.py
@@ -67,7 +67,7 @@ def _load_plotter_html(page: Page, plotter: Plotter) -> None:
     """
     # Simulate what show() does
     plotter._renderer.create_container(plotter._container_id)
-    html = plotter._renderer._generate_standalone_html()
+    html = plotter.generate_standalone_html()
 
     # Write to temp file and navigate to it
     with tempfile.NamedTemporaryFile(mode="w", suffix=".html", delete=False) as f:

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -271,7 +271,7 @@ def test_multiple_meshes_unique_variables(monkeypatch) -> None:
 
 
 def test_generate_standalone_html(monkeypatch) -> None:
-    """Test that _generate_standalone_html produces a complete HTML page with scene data."""
+    """Test that generate_standalone_html produces a complete HTML page with scene data."""
     from tests.conftest import extract_scene_data  # noqa: PLC0415
 
     monkeypatch.setattr(rendering, "IPYTHON_AVAILABLE", True)
@@ -279,7 +279,7 @@ def test_generate_standalone_html(monkeypatch) -> None:
     renderer = rendering.VTKJSRenderer()
     renderer.add_mesh_actor(Sphere(), color="red")
 
-    html = renderer._generate_standalone_html()
+    html = renderer.generate_standalone_html()
 
     assert "<!DOCTYPE html>" in html
     assert 'id="scene-data"' in html


### PR DESCRIPTION
## Summary
- Rename `_generate_standalone_html` → `generate_standalone_html` in renderer classes
- Add `Plotter.generate_standalone_html()` as delegating public API
- Update tests to use public method names

Closes #389