### PR TITLE
ci: add .aider* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ assets/*.gif
 # Node.js (TypeScript build)
 node_modules/
 src/pyvista_js/templates/renderer.js
+.aider*


### PR DESCRIPTION
Add .aider* pattern to .gitignore to exclude aider-related files from version control