### PR TITLE
feat: add fill_holes filter to PolyData

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ assets/*.gif
 # Node.js (TypeScript build)
 node_modules/
 src/pyvista_js/templates/renderer.js
+.aider*

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -92,6 +92,7 @@ This section provides detailed documentation for the pyvista-js public API.
 
    pyvista_js.PolyData.clip
    pyvista_js.PolyData.contour
+   pyvista_js.PolyData.fill_holes
    pyvista_js.PolyData.shrink
    pyvista_js.PolyData.texture_map_to_plane
    pyvista_js.PolyData.tube

--- a/src/pyvista_js/mesh.py
+++ b/src/pyvista_js/mesh.py
@@ -852,6 +852,17 @@ class PolyData:
         >>> isinstance(filled, pv.PolyData)
         True
 
+        Create a sphere with a hole and fill it:
+
+        >>> import pyvista_js as pv
+        >>> import numpy as np
+        >>> # Create a sphere with a hole by clipping
+        >>> sphere = pv.Sphere(radius=1.0)
+        >>> clipped_sphere = sphere.clip(normal='z', origin=(0, 0, 0.5))
+        >>> # Fill the hole
+        >>> filled_sphere = clipped_sphere.fill_holes(hole_size=10.0)
+        >>> filled_sphere.plot()  # doctest: +SKIP
+
         Render the filled mesh:
 
         >>> filled.plot()  # doctest: +SKIP
@@ -1028,17 +1039,6 @@ def Sphere(  # noqa: N802
     >>> sphere = pv.Sphere(radius=1.0)
     >>> sphere.n_points
     842
-
-    Create a sphere with a hole and fill it:
-
-    >>> import pyvista_js as pv
-    >>> import numpy as np
-    >>> # Create a sphere with a hole by clipping
-    >>> sphere = pv.Sphere(radius=1.0)
-    >>> clipped_sphere = sphere.clip(normal='z', origin=(0, 0, 0.5))
-    >>> # Fill the hole
-    >>> filled_sphere = clipped_sphere.fill_holes(hole_size=10.0)
-    >>> filled_sphere.plot()  # doctest: +SKIP
 
     """
     # Generate points matching vtk.js vtkSphereSource ordering exactly:

--- a/src/pyvista_js/mesh.py
+++ b/src/pyvista_js/mesh.py
@@ -809,6 +809,81 @@ class PolyData:
             raise ValueError(msg)
         return contour_values
 
+    def fill_holes(self, hole_size: float = 1000.0) -> PolyData:
+        """Fill holes in a polygonal mesh.
+
+        This filter identifies and fills holes in the mesh by locating
+        boundary edges, linking them together into loops, and then
+        triangulating the resulting loops. A hole size threshold controls
+        which holes are filled.
+
+        It mirrors the PyVista ``fill_holes`` filter API and replicates
+        the behavior of the vtk.js FillHolesFilter example.
+
+        .. note::
+
+            The hole filling is computed in JavaScript at render time by
+            finding boundary edges (edges belonging to only one polygon),
+            linking them into loops, and fan-triangulating each loop whose
+            perimeter is smaller than ``hole_size``.
+
+        Parameters
+        ----------
+        hole_size : float, optional
+            The maximum hole size to fill, specified as the length of the
+            perimeter of the hole. Holes with a perimeter larger than this
+            value will not be filled. Default is 1000.0.
+
+        Returns
+        -------
+        PolyData
+            A new mesh with holes filled.
+
+        Raises
+        ------
+        ValueError
+            If ``hole_size`` is not positive.
+
+        Examples
+        --------
+        >>> import pyvista_js as pv
+        >>> sphere = pv.Sphere()
+        >>> filled = sphere.fill_holes(hole_size=100.0)
+        >>> isinstance(filled, pv.PolyData)
+        True
+
+        Render the filled mesh:
+
+        >>> filled.plot()  # doctest: +SKIP
+
+        """
+        if hole_size <= 0:
+            msg = f"hole_size must be positive, got {hole_size}"
+            raise ValueError(msg)
+
+        base_scene = (
+            dict(self._scene_data)
+            if self._scene_data
+            else {
+                "type": "mesh",
+                "points": self.points.flatten().tolist(),
+            }
+        )
+        base_scene.setdefault("filters", [])
+        filters_list: list[object] = base_scene["filters"]  # type: ignore[assignment]
+        filters_list.append(
+            {
+                "type": "fillHoles",
+                "holeSize": hole_size,
+            },
+        )
+
+        return PolyData(
+            points=self.points,
+            faces=self.faces,
+            _scene_data=base_scene,
+        )
+
     def texture_map_to_plane(self) -> PolyData:
         """Generate texture coordinates by projecting points onto the XY plane.
 

--- a/src/pyvista_js/mesh.py
+++ b/src/pyvista_js/mesh.py
@@ -1029,6 +1029,17 @@ def Sphere(  # noqa: N802
     >>> sphere.n_points
     842
 
+    Create a sphere with a hole and fill it:
+
+    >>> import pyvista_js as pv
+    >>> import numpy as np
+    >>> # Create a sphere with a hole by clipping
+    >>> sphere = pv.Sphere(radius=1.0)
+    >>> clipped_sphere = sphere.clip(normal='z', origin=(0, 0, 0.5))
+    >>> # Fill the hole
+    >>> filled_sphere = clipped_sphere.fill_holes(hole_size=10.0)
+    >>> filled_sphere.plot()  # doctest: +SKIP
+
     """
     # Generate points matching vtk.js vtkSphereSource ordering exactly:
     #   index 0: north pole

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -494,6 +494,67 @@ def test_contour_custom_scalar_name() -> None:
     assert scene["filters"][-1]["scalarName"] == "custom_field"
 
 
+def test_fill_holes_returns_polydata() -> None:
+    """Test that fill_holes returns a PolyData instance."""
+    sphere = Sphere()
+    filled = sphere.fill_holes(hole_size=100.0)
+    assert isinstance(filled, PolyData)
+    assert filled.n_points == sphere.n_points
+
+
+def test_fill_holes_default_hole_size() -> None:
+    """Test that fill_holes works with default hole_size."""
+    cube = Cube()
+    filled = cube.fill_holes()
+    assert isinstance(filled, PolyData)
+
+
+def test_fill_holes_scene_data_contains_filter() -> None:
+    """Test that filled mesh scene data includes a fillHoles filter."""
+    sphere = Sphere()
+    filled = sphere.fill_holes(hole_size=50.0)
+    scene = filled.to_scene_data()
+    assert "filters" in scene
+    filters = scene["filters"]
+    assert len(filters) >= 1
+    assert filters[-1]["type"] == "fillHoles"
+    assert filters[-1]["holeSize"] == 50.0
+
+
+def test_fill_holes_scene_data_has_source_type() -> None:
+    """Test that filled mesh scene data preserves the source type."""
+    sphere = Sphere()
+    filled = sphere.fill_holes(hole_size=100.0)
+    scene = filled.to_scene_data()
+    assert scene["type"] == "sphere"
+
+
+def test_fill_holes_invalid_size() -> None:
+    """Test that an invalid hole_size raises ValueError."""
+    sphere = Sphere()
+    with pytest.raises(ValueError, match="hole_size must be positive"):
+        sphere.fill_holes(hole_size=0)
+    with pytest.raises(ValueError, match="hole_size must be positive"):
+        sphere.fill_holes(hole_size=-1.0)
+
+
+def test_fill_holes_preserves_faces() -> None:
+    """Test that fill_holes preserves face information."""
+    cube = Cube()
+    filled = cube.fill_holes(hole_size=100.0)
+    assert filled.n_faces == cube.n_faces
+
+
+def test_fill_holes_chained_with_shrink() -> None:
+    """Test that fill_holes can be chained with other filters."""
+    sphere = Sphere()
+    result = sphere.shrink(shrink_factor=0.8).fill_holes(hole_size=100.0)
+    scene = result.to_scene_data()
+    assert len(scene["filters"]) == 2
+    assert scene["filters"][0]["type"] == "shrink"
+    assert scene["filters"][1]["type"] == "fillHoles"
+
+
 def test_circle_creation() -> None:
     """Test circle primitive creation."""
     circle = Circle()

--- a/ts/renderer.ts
+++ b/ts/renderer.ts
@@ -722,7 +722,7 @@ function setupTextActor(cfg: TextActorConfig, containerElement: HTMLElement): vo
 }
 
 /**
- * Apply a chain of filters (shrink, tube, clip, contour) to a source.
+ * Apply a chain of filters to a source.
  * @param sourceResult
  * @param filters
  * @returns The final {@link SourceResult} after all filters have been applied in sequence.

--- a/ts/renderer.ts
+++ b/ts/renderer.ts
@@ -738,6 +738,8 @@ function applyFilters(sourceResult: SourceResult, filters: FilterConfig[]): Sour
       current = applyClipFilter(current, f.normal, f.origin, f.invert);
     } else if (f.type === "contour" && f.values && f.scalarName && f.scalarData) {
       current = applyContourFilter(current, f.values, f.scalarName, f.scalarData);
+    } else if (f.type === "fillHoles" && f.holeSize !== undefined) {
+      current = applyFillHolesFilter(current, f.holeSize);
     }
   }
 
@@ -1058,5 +1060,153 @@ function applyContourManual(
     outputPd.getLines().setData(new Uint32Array(outPolys));
   }
 
+  return { output: outputPd, isFilter: false };
+}
+
+/**
+ * Build an adjacency map of boundary edges (edges shared by exactly one cell).
+ * @param polys - The polygon connectivity array.
+ * @returns A map from vertex index to its boundary-adjacent vertex indices.
+ */
+function buildBoundaryAdjacency(polys: Uint32Array): Map<number, number[]> {
+  const edgeCount = new Map<string, number>();
+  let index = 0;
+  while (index < polys.length) {
+    const nVerts = at(polys, index);
+    index++;
+    for (let k = 0; k < nVerts; k++) {
+      const a = at(polys, index + k);
+      const b = at(polys, index + ((k + 1) % nVerts));
+      const key = `${String(Math.min(a, b))}_${String(Math.max(a, b))}`;
+      edgeCount.set(key, (edgeCount.get(key) ?? 0) + 1);
+    }
+
+    index += nVerts;
+  }
+
+  const boundaryAdj = new Map<number, number[]>();
+  for (const [key, count] of edgeCount) {
+    if (count !== 1) continue;
+    const parts = key.split("_");
+    const a = Number(parts[0]);
+    const b = Number(parts[1]);
+    const adjA = boundaryAdj.get(a);
+    if (adjA) {
+      adjA.push(b);
+    } else {
+      boundaryAdj.set(a, [b]);
+    }
+
+    const adjB = boundaryAdj.get(b);
+    if (adjB) {
+      adjB.push(a);
+    } else {
+      boundaryAdj.set(b, [a]);
+    }
+  }
+
+  return boundaryAdj;
+}
+
+/**
+ * Trace closed loops from boundary adjacency.
+ * @param boundaryAdj - Boundary adjacency map from {@link buildBoundaryAdjacency}.
+ * @returns An array of loops, each being an array of vertex indices.
+ */
+function traceBoundaryLoops(boundaryAdj: Map<number, number[]>): number[][] {
+  const visited = new Set<number>();
+  const loops: number[][] = [];
+  for (const startNode of boundaryAdj.keys()) {
+    if (visited.has(startNode)) continue;
+    const loop: number[] = [];
+    let current = startNode;
+    let previous = -1;
+    let stuck = false;
+    while (!stuck) {
+      visited.add(current);
+      loop.push(current);
+      const neighbors = boundaryAdj.get(current) ?? [];
+      let next = -1;
+      for (const n of neighbors) {
+        if (n !== previous && !visited.has(n)) {
+          next = n;
+          break;
+        }
+      }
+
+      if (next === -1) {
+        stuck = true;
+      } else {
+        previous = current;
+        current = next;
+      }
+    }
+
+    if (loop.length > 2) {
+      loops.push(loop);
+    }
+  }
+
+  return loops;
+}
+
+/**
+ * Fill holes in a polygonal mesh by finding boundary edges, linking them
+ * into loops, and fan-triangulating each loop whose perimeter is within
+ * the given size threshold.
+ *
+ * This replicates the behaviour of the vtk.js FillHolesFilter example.
+ * @param sourceResult
+ * @param holeSize
+ * @returns A {@link SourceResult} with holes filled.
+ */
+function applyFillHolesFilter(sourceResult: SourceResult, holeSize: number): SourceResult {
+  const inputPd = getPolyData(sourceResult);
+  const inPoints = inputPd.getPoints().getData();
+  const polys = inputPd.getPolys().getData();
+  if (polys.length === 0) {
+    return sourceResult;
+  }
+
+  const boundaryAdj = buildBoundaryAdjacency(polys);
+  if (boundaryAdj.size === 0) {
+    return sourceResult;
+  }
+
+  const loops = traceBoundaryLoops(boundaryAdj);
+
+  // Compute perimeter of each loop and fan-triangulate if within holeSize
+  const newPolys: number[] = [];
+  for (const loop of loops) {
+    let perimeter = 0;
+    for (let k = 0; k < loop.length; k++) {
+      const a = loop[k] ?? 0;
+      const b = loop[(k + 1) % loop.length] ?? 0;
+      const dx = at(inPoints, b * 3) - at(inPoints, a * 3);
+      const dy = at(inPoints, b * 3 + 1) - at(inPoints, a * 3 + 1);
+      const dz = at(inPoints, b * 3 + 2) - at(inPoints, a * 3 + 2);
+      perimeter += Math.hypot(dx, dy, dz);
+    }
+
+    if (perimeter <= holeSize) {
+      const v0 = loop[0] ?? 0;
+      for (let k = 1; k < loop.length - 1; k++) {
+        const v1 = loop[k] ?? 0;
+        const v2 = loop[k + 1] ?? 0;
+        newPolys.push(3, v0, v1, v2);
+      }
+    }
+  }
+
+  if (newPolys.length === 0) {
+    return sourceResult;
+  }
+
+  // Merge original polys with new fill polys
+  const mergedPolys = new Uint32Array([...polys, ...newPolys]);
+
+  const outputPd = vtk.Common.DataModel.vtkPolyData.newInstance();
+  outputPd.getPoints().setData(new Float32Array(inPoints), 3);
+  outputPd.getPolys().setData(mergedPolys);
   return { output: outputPd, isFilter: false };
 }

--- a/ts/vtk.d.ts
+++ b/ts/vtk.d.ts
@@ -328,7 +328,7 @@ type PointDataArray = {
   name: string;
 };
 
-/** Configuration for a geometry filter (shrink, tube, clip, or contour). */
+/** Configuration for a geometry filter (shrink, tube, clip, contour, or fillHoles). */
 type FilterConfig = {
   type: string;
   shrinkFactor?: number;
@@ -340,6 +340,7 @@ type FilterConfig = {
   values?: number[];
   scalarName?: string;
   scalarData?: number[];
+  holeSize?: number;
 };
 
 /** Configuration for a geometry source (primitive, mesh, or file reader). */

--- a/ts/vtk.d.ts
+++ b/ts/vtk.d.ts
@@ -328,7 +328,7 @@ type PointDataArray = {
   name: string;
 };
 
-/** Configuration for a geometry filter (shrink, tube, clip, contour, or fillHoles). */
+/** Configuration for a geometry filter. */
 type FilterConfig = {
   type: string;
   shrinkFactor?: number;


### PR DESCRIPTION
## Summary
- Add `PolyData.fill_holes(hole_size=1000.0)` method that fills holes in polygonal meshes, replicating the vtk.js FillHolesFilter example functionality
- Implement a custom JavaScript fill-holes algorithm in `renderer.ts` that finds boundary edges, traces them into loops, and fan-triangulates each loop whose perimeter is within the `hole_size` threshold
- Add `holeSize` field to `FilterConfig` type in `vtk.d.ts`
- Add 7 tests covering return type, default parameters, scene data, source type preservation, validation, face preservation, and filter chaining

## Test plan
- [x] All 551 existing tests pass
- [x] 7 new fill_holes-specific tests pass
- [x] TypeScript type-checks with `tsc --noEmit`
- [x] Linting passes with `xo`
- [ ] Manual verification: create a mesh with holes, apply `fill_holes()`, and visually confirm holes are filled in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)