### PR TITLE
feat: add UnstructuredGrid and CellType for 3D cell support

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -50,6 +50,8 @@ This section provides detailed documentation for the pyvista-js public API.
    :nosignatures:
 
    pyvista_js.PolyData
+   pyvista_js.UnstructuredGrid
+   pyvista_js.CellType
    pyvista_js.Arrow
    pyvista_js.Sphere
    pyvista_js.Cube

--- a/src/pyvista_js/__init__.pyi
+++ b/src/pyvista_js/__init__.pyi
@@ -1,6 +1,7 @@
 __all__ = [
     "Arrow",
     "Camera",
+    "CellType",
     "Circle",
     "Cone",
     "Cube",
@@ -21,6 +22,7 @@ __all__ = [
     "Text",
     "TextProperty",
     "Texture",
+    "UnstructuredGrid",
     "__version__",
     "examples",
     "pyvista_chart",
@@ -36,6 +38,7 @@ from .camera import Camera
 from .light import Light
 from .mesh import (
     Arrow,
+    CellType,
     Circle,
     Cone,
     Cube,
@@ -46,6 +49,7 @@ from .mesh import (
     PointData,
     PolyData,
     Sphere,
+    UnstructuredGrid,
 )
 from .plotter import Plotter
 from .readers import GLTFReader, OBJReader, PLYReader, PolyDataReader, STLReader

--- a/src/pyvista_js/mesh.py
+++ b/src/pyvista_js/mesh.py
@@ -1038,6 +1038,8 @@ class UnstructuredGrid:
 
     Create a hexahedron (cube):
 
+    >>> import pyvista_js as pv
+    >>> import numpy as np
     >>> points = np.array([
     ...     [0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0],  # bottom face
     ...     [0, 0, 1], [1, 0, 1], [1, 1, 1], [0, 1, 1],  # top face
@@ -1052,6 +1054,8 @@ class UnstructuredGrid:
 
     Create a mixed mesh with multiple cell types:
 
+    >>> import pyvista_js as pv
+    >>> import numpy as np
     >>> # Triangle and quad cells
     >>> points = np.array([
     ...     [0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0],  # vertices
@@ -1064,6 +1068,9 @@ class UnstructuredGrid:
 
     Access point data:
 
+    >>> import pyvista_js as pv
+    >>> import numpy as np
+    >>> points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
     >>> grid = pv.UnstructuredGrid([4, 0, 1, 2, 3], [pv.CellType.TETRA], points)
     >>> grid['temperature'] = np.array([20.0, 25.0, 22.0, 24.0])
     >>> grid['temperature']
@@ -1071,6 +1078,9 @@ class UnstructuredGrid:
 
     Plot the grid:
 
+    >>> import pyvista_js as pv
+    >>> import numpy as np
+    >>> points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
     >>> grid = pv.UnstructuredGrid([4, 0, 1, 2, 3], [pv.CellType.TETRA], points)
     >>> grid.plot()  # doctest: +SKIP
 
@@ -1114,6 +1124,7 @@ class UnstructuredGrid:
         Examples
         --------
         >>> import numpy as np
+        >>> import pyvista_js as pv
         >>> points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
         >>> grid = pv.UnstructuredGrid([4, 0, 1, 2, 3], [pv.CellType.TETRA], points)
         >>> # Set temperature data
@@ -1142,6 +1153,7 @@ class UnstructuredGrid:
         Examples
         --------
         >>> import numpy as np
+        >>> import pyvista_js as pv
         >>> points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
         >>> grid = pv.UnstructuredGrid([4, 0, 1, 2, 3], [pv.CellType.TETRA], points)
         >>> grid['temperature'] = np.array([20.0, 25.0, 22.0, 24.0])
@@ -1167,6 +1179,7 @@ class UnstructuredGrid:
         Examples
         --------
         >>> import numpy as np
+        >>> import pyvista_js as pv
         >>> points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
         >>> grid = pv.UnstructuredGrid([4, 0, 1, 2, 3], [pv.CellType.TETRA], points)
         >>> grid.n_points
@@ -1187,12 +1200,16 @@ class UnstructuredGrid:
         Examples
         --------
         >>> import numpy as np
+        >>> import pyvista_js as pv
         >>> points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
         >>> grid = pv.UnstructuredGrid([4, 0, 1, 2, 3], [pv.CellType.TETRA], points)
         >>> grid.n_cells
         1
 
         >>> # Multiple cells
+        >>> import numpy as np
+        >>> import pyvista_js as pv
+        >>> points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
         >>> cells = [3, 0, 1, 2, 4, 1, 2, 3, 0]  # triangle + quad
         >>> celltypes = [pv.CellType.TRIANGLE, pv.CellType.QUAD]
         >>> grid = pv.UnstructuredGrid(cells, celltypes, points[:4])

--- a/src/pyvista_js/mesh.py
+++ b/src/pyvista_js/mesh.py
@@ -129,6 +129,42 @@ _CIRCLE_MIN_RESOLUTION = 3
 _VECTOR_COMPONENTS = 3  # Number of components in a 3D vector (x, y, z)
 _TUBE_MIN_SIDES = 3
 
+# VTK cell type constants
+_CELL_TYPE_VERTEX = 1
+_CELL_TYPE_LINE = 3
+_CELL_TYPE_TRIANGLE = 5
+_CELL_TYPE_QUAD = 9
+_CELL_TYPE_TETRA = 10
+_CELL_TYPE_HEXAHEDRON = 12
+_CELL_TYPE_WEDGE = 13
+_CELL_TYPE_PYRAMID = 14
+
+
+class CellType:
+    """VTK cell type constants.
+
+    Provides named constants for the most common VTK cell types,
+    matching the :class:`pyvista.CellType` API.
+
+    Examples
+    --------
+    >>> import pyvista_js as pv
+    >>> pv.CellType.TETRA
+    10
+    >>> pv.CellType.HEXAHEDRON
+    12
+
+    """
+
+    VERTEX: int = _CELL_TYPE_VERTEX
+    LINE: int = _CELL_TYPE_LINE
+    TRIANGLE: int = _CELL_TYPE_TRIANGLE
+    QUAD: int = _CELL_TYPE_QUAD
+    TETRA: int = _CELL_TYPE_TETRA
+    HEXAHEDRON: int = _CELL_TYPE_HEXAHEDRON
+    WEDGE: int = _CELL_TYPE_WEDGE
+    PYRAMID: int = _CELL_TYPE_PYRAMID
+
 
 class PolyData:
     """Base polygonal mesh class.
@@ -921,6 +957,300 @@ class PolyData:
         self.t_coords = state["t_coords"]  # type: ignore[assignment]
         self._point_data = state["_point_data"]  # type: ignore[assignment]
         self._scene_data = state.get("_scene_data")  # type: ignore[assignment]
+
+
+class UnstructuredGrid:
+    """Unstructured grid dataset.
+
+    An unstructured grid can hold cells of arbitrary type (tetrahedra,
+    hexahedra, wedges, pyramids, triangles, quads, etc.).  This class
+    mirrors the :class:`pyvista.UnstructuredGrid` constructor API.
+
+    For rendering in vtk.js the 3-D cells are decomposed into their
+    surface faces so that they can be displayed as polygonal geometry.
+
+    Parameters
+    ----------
+    cells : array-like
+        Cell connectivity in VTK format:
+        ``[n_pts0, p0, p1, ..., n_pts1, p0, p1, ...]``.
+    celltypes : array-like
+        Array of VTK cell type constants (see :class:`CellType`) – one
+        value per cell.
+    points : array-like
+        Vertex coordinates as an ``(n, 3)`` array.
+
+    Examples
+    --------
+    Create a single tetrahedron:
+
+    >>> import pyvista_js as pv
+    >>> import numpy as np
+    >>> points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+    >>> cells = [4, 0, 1, 2, 3]
+    >>> celltypes = [pv.CellType.TETRA]
+    >>> grid = pv.UnstructuredGrid(cells, celltypes, points)
+    >>> grid.n_points
+    4
+    >>> grid.n_cells
+    1
+
+    """
+
+    def __init__(
+        self,
+        cells: ArrayLike,
+        celltypes: ArrayLike,
+        points: ArrayLike,
+    ) -> None:
+        """Initialize an UnstructuredGrid."""
+        self.points = np.asarray(points, dtype=float)
+        self.cells = np.asarray(cells)
+        self.celltypes = np.asarray(celltypes)
+        self._point_data = PointData()
+        self._scene_data: dict[str, object] | None = None
+
+    @property
+    def point_data(self) -> PointData:
+        """Access point data arrays.
+
+        Returns
+        -------
+        PointData
+            Dict-like container for point data arrays.
+
+        """
+        return self._point_data
+
+    def __setitem__(self, name: str, array: ArrayLike) -> None:
+        """Set a point data array using dictionary-style access.
+
+        Parameters
+        ----------
+        name : str
+            Name of the array.
+        array : array-like
+            Data array to store.
+
+        """
+        self._point_data[name] = array
+
+    def __getitem__(self, name: str) -> np.ndarray:
+        """Get a point data array using dictionary-style access.
+
+        Parameters
+        ----------
+        name : str
+            Name of the array.
+
+        Returns
+        -------
+        np.ndarray
+            The requested array.
+
+        """
+        return self._point_data[name]
+
+    @property
+    def n_points(self) -> int:
+        """Return the number of points."""
+        return len(self.points)
+
+    @property
+    def n_cells(self) -> int:
+        """Return the number of cells."""
+        return len(self.celltypes)
+
+    @property
+    def bounding_sphere(self) -> tuple[float, tuple[float, float, float]]:
+        """Compute the radius and center of a bounding sphere.
+
+        Uses Ritter's algorithm to approximate the minimum bounding sphere.
+        Returns NaN values if there are no points.
+
+        Returns
+        -------
+        float, tuple
+            Sphere radius as a float and center as a tuple of floats ``(x, y, z)``.
+
+        """
+        if self.n_points == 0:
+            nan = float("nan")
+            return nan, (nan, nan, nan)
+
+        pts = self.points.astype(float)
+
+        p = pts[0]
+        dists = np.linalg.norm(pts - p, axis=1)
+        q = pts[np.argmax(dists)]
+        dists = np.linalg.norm(pts - q, axis=1)
+        r = pts[np.argmax(dists)]
+
+        center = (q + r) / 2.0
+        radius = float(np.linalg.norm(r - q) / 2.0)
+
+        for pt in pts:
+            d = float(np.linalg.norm(pt - center))
+            if d > radius:
+                radius = (radius + d) / 2.0
+                center = center + (d - radius) / d * (pt - center)
+
+        return radius, (float(center[0]), float(center[1]), float(center[2]))
+
+    def _extract_surface_polys(self) -> list[int]:
+        """Extract surface faces from cells as a flat VTK polys array.
+
+        Returns
+        -------
+        list[int]
+            Flat list in VTK cell-array format:
+            ``[n0, p0, p1, ..., n1, p0, p1, ...]``.
+
+        """
+        # Face definitions per cell type (local point indices)
+        _TETRA_FACES = (  # noqa: N806
+            (0, 1, 2),
+            (0, 3, 1),
+            (1, 3, 2),
+            (0, 2, 3),
+        )
+        _HEX_FACES = (  # noqa: N806
+            (0, 3, 2, 1),
+            (4, 5, 6, 7),
+            (0, 1, 5, 4),
+            (2, 3, 7, 6),
+            (0, 4, 7, 3),
+            (1, 2, 6, 5),
+        )
+        _WEDGE_FACES = (  # noqa: N806
+            (0, 1, 2),
+            (3, 5, 4),
+            (0, 3, 4, 1),
+            (1, 4, 5, 2),
+            (0, 2, 5, 3),
+        )
+        _PYRAMID_FACES = (  # noqa: N806
+            (0, 3, 2, 1),
+            (0, 1, 4),
+            (1, 2, 4),
+            (2, 3, 4),
+            (3, 0, 4),
+        )
+
+        polys: list[int] = []
+        idx = 0
+        cells = self.cells
+        for cell_type in self.celltypes:
+            n_pts = int(cells[idx])
+            pts = cells[idx + 1 : idx + 1 + n_pts]
+            idx += n_pts + 1
+
+            if cell_type == _CELL_TYPE_TETRA:
+                face_defs = _TETRA_FACES
+            elif cell_type == _CELL_TYPE_HEXAHEDRON:
+                face_defs = _HEX_FACES
+            elif cell_type == _CELL_TYPE_WEDGE:
+                face_defs = _WEDGE_FACES
+            elif cell_type == _CELL_TYPE_PYRAMID:
+                face_defs = _PYRAMID_FACES
+            elif cell_type == _CELL_TYPE_TRIANGLE:
+                face_defs = ((0, 1, 2),)
+            elif cell_type == _CELL_TYPE_QUAD:
+                face_defs = ((0, 1, 2, 3),)
+            else:
+                continue
+
+            for face in face_defs:
+                polys.append(len(face))
+                polys.extend(int(pts[i]) for i in face)
+
+        return polys
+
+    def plot(
+        self,
+        color: str | tuple[float, float, float] | None = None,
+        opacity: float = 1.0,
+        pbr: bool = False,  # noqa: FBT001 FBT002
+        metallic: float = 0.0,
+        roughness: float = 0.5,
+    ) -> None:
+        """Plot this grid.
+
+        This is a convenience method that creates a :class:`~pyvista_js.Plotter`,
+        adds this grid, and calls :func:`~pyvista_js.Plotter.show`.
+
+        Parameters
+        ----------
+        color : str or tuple, optional
+            Color of the mesh.
+        opacity : float, optional
+            Opacity, between 0 and 1. Default is 1.
+        pbr : bool, optional
+            Enable physically based rendering. Default is False.
+        metallic : float, optional
+            Metallic factor for PBR. Default is 0.0.
+        roughness : float, optional
+            Roughness factor for PBR. Default is 0.5.
+
+        Examples
+        --------
+        >>> import pyvista_js as pv
+        >>> import numpy as np
+        >>> points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+        >>> grid = pv.UnstructuredGrid([4, 0, 1, 2, 3], [pv.CellType.TETRA], points)
+        >>> grid.plot()  # doctest: +SKIP
+
+        """
+        from .plotter import Plotter  # noqa: PLC0415
+
+        plotter = Plotter()
+        plotter.add_mesh(
+            self,
+            color=color,
+            opacity=opacity,
+            pbr=pbr,
+            metallic=metallic,
+            roughness=roughness,
+        )
+        plotter.show()
+
+    def to_scene_data(self) -> dict[str, object]:
+        """Return a JSON-serializable dict describing this grid.
+
+        The 3-D cells are decomposed into their surface polygons so that
+        they can be rendered as a ``"mesh"`` source in vtk.js.
+
+        Returns
+        -------
+        dict
+            Source configuration with ``"type": "mesh"``.
+
+        """
+        if self._scene_data is not None:
+            data: dict[str, object] = dict(self._scene_data)
+        else:
+            polys = self._extract_surface_polys()
+            data = {
+                "type": "mesh",
+                "points": self.points.flatten().tolist(),
+                "polys": polys,
+            }
+
+        # Inject point data arrays
+        if len(self._point_data) > 0:
+            point_data_arrays: list[dict[str, object]] = []
+            for name, array in self._point_data.items():
+                n_components = 1 if array.ndim == 1 else array.shape[1]
+                point_data_arrays.append(
+                    {
+                        "name": name,
+                        "numberOfComponents": n_components,
+                        "values": array.flatten().tolist(),
+                    },
+                )
+            data["pointData"] = point_data_arrays
+
+        return data
 
 
 def Sphere(  # noqa: N802

--- a/src/pyvista_js/mesh.py
+++ b/src/pyvista_js/mesh.py
@@ -146,13 +146,54 @@ class CellType:
     Provides named constants for the most common VTK cell types,
     matching the :class:`pyvista.CellType` API.
 
+    These constants are used to define the type of cells in an
+    :class:`UnstructuredGrid`. Each cell type corresponds to a specific
+    VTK cell type identifier.
+
     Examples
     --------
+    Basic usage:
+
     >>> import pyvista_js as pv
     >>> pv.CellType.TETRA
     10
     >>> pv.CellType.HEXAHEDRON
     12
+    >>> pv.CellType.TRIANGLE
+    5
+    >>> pv.CellType.QUAD
+    9
+
+    Use with UnstructuredGrid:
+
+    >>> import numpy as np
+    >>> points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+    >>> cells = [4, 0, 1, 2, 3]
+    >>> celltypes = [pv.CellType.TETRA]  # Use the constant
+    >>> grid = pv.UnstructuredGrid(cells, celltypes, points)
+
+    Available cell types:
+
+    >>> # 0-D cells
+    >>> pv.CellType.VERTEX  # Single point
+    1
+    >>> # 1-D cells
+    >>> pv.CellType.LINE  # Line segment
+    3
+    >>> # 2-D cells
+    >>> pv.CellType.TRIANGLE  # 3-point triangle
+    5
+    >>> pv.CellType.QUAD  # 4-point quadrilateral
+    9
+    >>> # 3-D cells
+    >>> pv.CellType.TETRA  # 4-point tetrahedron
+    10
+    >>> pv.CellType.HEXAHEDRON  # 8-point hexahedron (cube)
+    12
+    >>> pv.CellType.WEDGE  # 6-point triangular prism
+    13
+    >>> pv.CellType.PYRAMID  # 5-point pyramid
+    14
 
     """
 
@@ -995,6 +1036,44 @@ class UnstructuredGrid:
     >>> grid.n_cells
     1
 
+    Create a hexahedron (cube):
+
+    >>> points = np.array([
+    ...     [0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0],  # bottom face
+    ...     [0, 0, 1], [1, 0, 1], [1, 1, 1], [0, 1, 1],  # top face
+    ... ], dtype=float)
+    >>> cells = [8, 0, 1, 2, 3, 4, 5, 6, 7]
+    >>> celltypes = [pv.CellType.HEXAHEDRON]
+    >>> grid = pv.UnstructuredGrid(cells, celltypes, points)
+    >>> grid.n_points
+    8
+    >>> grid.n_cells
+    1
+
+    Create a mixed mesh with multiple cell types:
+
+    >>> # Triangle and quad cells
+    >>> points = np.array([
+    ...     [0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0],  # vertices
+    ... ], dtype=float)
+    >>> cells = [3, 0, 1, 2, 4, 1, 2, 3, 0]  # triangle, quad
+    >>> celltypes = [pv.CellType.TRIANGLE, pv.CellType.QUAD]
+    >>> grid = pv.UnstructuredGrid(cells, celltypes, points)
+    >>> grid.n_cells
+    2
+
+    Access point data:
+
+    >>> grid = pv.UnstructuredGrid([4, 0, 1, 2, 3], [pv.CellType.TETRA], points)
+    >>> grid['temperature'] = np.array([20.0, 25.0, 22.0, 24.0])
+    >>> grid['temperature']
+    array([20., 25., 22., 24.])
+
+    Plot the grid:
+
+    >>> grid = pv.UnstructuredGrid([4, 0, 1, 2, 3], [pv.CellType.TETRA], points)
+    >>> grid.plot()  # doctest: +SKIP
+
     """
 
     def __init__(
@@ -1032,6 +1111,18 @@ class UnstructuredGrid:
         array : array-like
             Data array to store.
 
+        Examples
+        --------
+        >>> import numpy as np
+        >>> points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+        >>> grid = pv.UnstructuredGrid([4, 0, 1, 2, 3], [pv.CellType.TETRA], points)
+        >>> # Set temperature data
+        >>> grid['temperature'] = np.array([20.0, 25.0, 22.0, 24.0])
+        >>> # Set vector data
+        >>> grid['velocity'] = np.array(
+        ...     [[0, 0, 1], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float
+        ... )
+
         """
         self._point_data[name] = array
 
@@ -1048,17 +1139,67 @@ class UnstructuredGrid:
         np.ndarray
             The requested array.
 
+        Examples
+        --------
+        >>> import numpy as np
+        >>> points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+        >>> grid = pv.UnstructuredGrid([4, 0, 1, 2, 3], [pv.CellType.TETRA], points)
+        >>> grid['temperature'] = np.array([20.0, 25.0, 22.0, 24.0])
+        >>> grid['temperature']
+        array([20., 25., 22., 24.])
+        >>> # Get vector data
+        >>> grid['velocity'] = np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+        >>> grid['velocity'].shape
+        (4, 3)
+
         """
         return self._point_data[name]
 
     @property
     def n_points(self) -> int:
-        """Return the number of points."""
+        """Return the number of points.
+
+        Returns
+        -------
+        int
+            Number of points in the grid.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+        >>> grid = pv.UnstructuredGrid([4, 0, 1, 2, 3], [pv.CellType.TETRA], points)
+        >>> grid.n_points
+        4
+
+        """
         return len(self.points)
 
     @property
     def n_cells(self) -> int:
-        """Return the number of cells."""
+        """Return the number of cells.
+
+        Returns
+        -------
+        int
+            Number of cells in the grid.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+        >>> grid = pv.UnstructuredGrid([4, 0, 1, 2, 3], [pv.CellType.TETRA], points)
+        >>> grid.n_cells
+        1
+
+        >>> # Multiple cells
+        >>> cells = [3, 0, 1, 2, 4, 1, 2, 3, 0]  # triangle + quad
+        >>> celltypes = [pv.CellType.TRIANGLE, pv.CellType.QUAD]
+        >>> grid = pv.UnstructuredGrid(cells, celltypes, points[:4])
+        >>> grid.n_cells
+        2
+
+        """
         return len(self.celltypes)
 
     @property

--- a/src/pyvista_js/mesh.py
+++ b/src/pyvista_js/mesh.py
@@ -975,7 +975,7 @@ class UnstructuredGrid:
         Cell connectivity in VTK format:
         ``[n_pts0, p0, p1, ..., n_pts1, p0, p1, ...]``.
     celltypes : array-like
-        Array of VTK cell type constants (see :class:`CellType`) – one
+        Array of VTK cell type constants (see :class:`CellType`) - one
         value per cell.
     points : array-like
         Vertex coordinates as an ``(n, 3)`` array.
@@ -1145,6 +1145,7 @@ class UnstructuredGrid:
             pts = cells[idx + 1 : idx + 1 + n_pts]
             idx += n_pts + 1
 
+            face_defs: tuple[tuple[int, ...], ...]
             if cell_type == _CELL_TYPE_TETRA:
                 face_defs = _TETRA_FACES
             elif cell_type == _CELL_TYPE_HEXAHEDRON:

--- a/src/pyvista_js/plotter.py
+++ b/src/pyvista_js/plotter.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from .camera import Camera
     from .examples import CubeMap
     from .light import Light
-    from .mesh import PolyData
+    from .mesh import PolyData, UnstructuredGrid
     from .text import Text
     from .texture import Texture
 
@@ -75,7 +75,7 @@ class Plotter:
 
     def add_mesh(  # noqa: PLR0913
         self,
-        mesh: PolyData,
+        mesh: PolyData | UnstructuredGrid,
         color: str | tuple[float, float, float] | None = None,
         opacity: float = 1.0,
         pbr: bool = False,  # noqa: FBT001 FBT002

--- a/src/pyvista_js/rendering.py
+++ b/src/pyvista_js/rendering.py
@@ -85,7 +85,7 @@ if TYPE_CHECKING:
 
     from .camera import Camera
     from .light import Light
-    from .mesh import PolyData
+    from .mesh import PolyData, UnstructuredGrid
     from .text import Text
     from .texture import Texture
 
@@ -257,7 +257,7 @@ class _BaseHTMLRenderer:
 
     def add_mesh_actor(  # noqa: PLR0913
         self,
-        mesh: PolyData,
+        mesh: PolyData | UnstructuredGrid,
         color: str | tuple[float, float, float] | None = None,
         opacity: float = 1.0,
         pbr: bool = False,  # noqa: FBT001 FBT002
@@ -1298,7 +1298,7 @@ class MockRenderer:
 
     def add_mesh_actor(  # noqa: PLR0913
         self,
-        mesh: PolyData,
+        mesh: PolyData | UnstructuredGrid,
         color: str | tuple[float, float, float] | None = None,
         opacity: float = 1.0,
         pbr: bool = False,  # noqa: FBT001 FBT002

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -837,11 +837,9 @@ def test_plane_scene_data_is_not_none() -> None:
     assert scene["type"] == "plane"
 
 
-meshio = pytest.importorskip("meshio")
-
-
 def test_save_obj(tmp_path) -> None:
     """Test that save writes a valid OBJ file via meshio."""
+    meshio = pytest.importorskip("meshio")
     cube = Cube()
     out = tmp_path / "cube.obj"
     cube.save(out)
@@ -853,6 +851,7 @@ def test_save_obj(tmp_path) -> None:
 
 def test_save_obj_vertex_coords(tmp_path) -> None:
     """Test that saved vertex coordinates match original points."""
+    meshio = pytest.importorskip("meshio")
     points = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
     mesh = PolyData(points)
     out = tmp_path / "mesh.obj"
@@ -863,6 +862,7 @@ def test_save_obj_vertex_coords(tmp_path) -> None:
 
 def test_save_vtk(tmp_path) -> None:
     """Test that save can write VTK format via meshio."""
+    meshio = pytest.importorskip("meshio")
     cube = Cube()
     out = tmp_path / "cube.vtk"
     cube.save(out)
@@ -888,6 +888,7 @@ def test_save_no_meshio(tmp_path, monkeypatch) -> None:
 
 def test_save_string_path(tmp_path) -> None:
     """Test that save accepts a string path."""
+    pytest.importorskip("meshio")  # Skip if meshio not available
     cube = Cube()
     out = str(tmp_path / "cube.obj")
     cube.save(out)

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -9,6 +9,7 @@ import pytest
 
 from pyvista_js import (
     Arrow,
+    CellType,
     Circle,
     Cone,
     Cube,
@@ -18,6 +19,7 @@ from pyvista_js import (
     Plane,
     PolyData,
     Sphere,
+    UnstructuredGrid,
 )
 
 
@@ -890,3 +892,170 @@ def test_save_string_path(tmp_path) -> None:
     out = str(tmp_path / "cube.obj")
     cube.save(out)
     assert Path(out).exists()
+
+
+# --- CellType constants ---
+
+
+def test_cell_type_constants() -> None:
+    """Test that CellType constants match VTK values."""
+    assert CellType.VERTEX == 1
+    assert CellType.LINE == 3
+    assert CellType.TRIANGLE == 5
+    assert CellType.QUAD == 9
+    assert CellType.TETRA == 10
+    assert CellType.HEXAHEDRON == 12
+    assert CellType.WEDGE == 13
+    assert CellType.PYRAMID == 14
+
+
+# --- UnstructuredGrid ---
+
+
+def _make_tetra_grid() -> UnstructuredGrid:
+    """Create a simple single-tetrahedron grid."""
+    points = np.array(
+        [[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]],
+        dtype=float,
+    )
+    cells = [4, 0, 1, 2, 3]
+    celltypes = [CellType.TETRA]
+    return UnstructuredGrid(cells, celltypes, points)
+
+
+def test_unstructured_grid_creation() -> None:
+    """Test basic UnstructuredGrid creation."""
+    grid = _make_tetra_grid()
+    assert grid.n_points == 4
+    assert grid.n_cells == 1
+
+
+def test_unstructured_grid_hexahedron() -> None:
+    """Test UnstructuredGrid with a hexahedron cell."""
+    points = np.array(
+        [
+            [0, 0, 0],
+            [1, 0, 0],
+            [1, 1, 0],
+            [0, 1, 0],
+            [0, 0, 1],
+            [1, 0, 1],
+            [1, 1, 1],
+            [0, 1, 1],
+        ],
+        dtype=float,
+    )
+    cells = [8, 0, 1, 2, 3, 4, 5, 6, 7]
+    celltypes = [CellType.HEXAHEDRON]
+    grid = UnstructuredGrid(cells, celltypes, points)
+    assert grid.n_points == 8
+    assert grid.n_cells == 1
+
+
+def test_unstructured_grid_to_scene_data_tetra() -> None:
+    """Test to_scene_data for tetrahedron produces correct polys."""
+    grid = _make_tetra_grid()
+    data = grid.to_scene_data()
+    assert data["type"] == "mesh"
+    assert "points" in data
+    assert "polys" in data
+    # A tetrahedron has 4 triangular faces, each [3, a, b, c] → 4 * 4 = 16 entries
+    polys = data["polys"]
+    assert len(polys) == 16
+    # Every face starts with 3 (triangle)
+    face_starts = [polys[i] for i in range(0, len(polys), 4)]
+    assert all(n == 3 for n in face_starts)
+
+
+def test_unstructured_grid_to_scene_data_hex() -> None:
+    """Test to_scene_data for hexahedron produces correct polys."""
+    points = np.array(
+        [
+            [0, 0, 0],
+            [1, 0, 0],
+            [1, 1, 0],
+            [0, 1, 0],
+            [0, 0, 1],
+            [1, 0, 1],
+            [1, 1, 1],
+            [0, 1, 1],
+        ],
+        dtype=float,
+    )
+    grid = UnstructuredGrid(
+        [8, 0, 1, 2, 3, 4, 5, 6, 7],
+        [CellType.HEXAHEDRON],
+        points,
+    )
+    data = grid.to_scene_data()
+    polys = data["polys"]
+    # 6 quad faces → each [4, a, b, c, d] → 6 * 5 = 30 entries
+    assert len(polys) == 30
+
+
+def test_unstructured_grid_point_data() -> None:
+    """Test that point_data arrays are injected into scene data."""
+    grid = _make_tetra_grid()
+    grid.point_data["temperature"] = np.array([100, 200, 300, 400])
+    data = grid.to_scene_data()
+    assert "pointData" in data
+    pd_arrays = data["pointData"]
+    assert len(pd_arrays) == 1
+    assert pd_arrays[0]["name"] == "temperature"
+    assert pd_arrays[0]["numberOfComponents"] == 1
+    assert pd_arrays[0]["values"] == [100.0, 200.0, 300.0, 400.0]
+
+
+def test_unstructured_grid_dict_access() -> None:
+    """Test dict-style point data access on UnstructuredGrid."""
+    grid = _make_tetra_grid()
+    grid["scalars"] = np.array([1.0, 2.0, 3.0, 4.0])
+    assert np.array_equal(grid["scalars"], [1.0, 2.0, 3.0, 4.0])
+
+
+def test_unstructured_grid_bounding_sphere() -> None:
+    """Test bounding_sphere for UnstructuredGrid."""
+    grid = _make_tetra_grid()
+    radius, center = grid.bounding_sphere
+    assert isinstance(radius, float)
+    assert isinstance(center, tuple)
+    assert len(center) == 3
+    assert radius > 0
+
+
+def test_unstructured_grid_plot(monkeypatch) -> None:
+    """Test that UnstructuredGrid.plot() opens a browser."""
+    opened: list[str] = []
+    monkeypatch.setattr(webbrowser, "open", opened.append)
+
+    grid = _make_tetra_grid()
+    grid.plot(color="red")
+
+    assert len(opened) == 1
+    assert opened[0].startswith("file://")
+
+
+def test_unstructured_grid_mixed_cells() -> None:
+    """Test UnstructuredGrid with mixed cell types."""
+    points = np.array(
+        [
+            # tetra points
+            [0, 0, 0],
+            [1, 0, 0],
+            [0, 1, 0],
+            [0, 0, 1],
+            # triangle points (separate)
+            [2, 0, 0],
+            [3, 0, 0],
+            [2, 1, 0],
+        ],
+        dtype=float,
+    )
+    cells = [4, 0, 1, 2, 3, 3, 4, 5, 6]
+    celltypes = [CellType.TETRA, CellType.TRIANGLE]
+    grid = UnstructuredGrid(cells, celltypes, points)
+    assert grid.n_cells == 2
+    data = grid.to_scene_data()
+    polys = data["polys"]
+    # tetra: 4 tri faces (16 entries) + 1 triangle (4 entries) = 20
+    assert len(polys) == 20


### PR DESCRIPTION
## Summary
This PR adds support for UnstructuredGrid and CellType to enable 3D cell visualization capabilities.

## Changes
- Added UnstructuredGrid class for handling 3D unstructured grid data
- Added CellType enum for defining different cell types
- Enhanced mesh module with 3D cell support
- Added comprehensive tests for new functionality

## Files Changed
- `src/pyvista_js/__init__.pyi` - Added type definitions
- `src/pyvista_js/mesh.py` - Added UnstructuredGrid and CellType implementations
- `tests/test_mesh.py` - Added test coverage for new features