### PR TITLE
fix: resolve mypy type errors for _scene_data parameter

### DIFF
--- a/src/pyvista_js/mesh.py
+++ b/src/pyvista_js/mesh.py
@@ -5,7 +5,7 @@ Provides geometric primitives and mesh handling compatible with PyVista API.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -227,7 +227,7 @@ class PolyData:
         t_coords: ArrayLike | None = None,
         scalars: ArrayLike | None = None,
         scalar_name: str = "scalars",
-        _scene_data: dict[str, object] | None = None,
+        _scene_data: dict[str, Any] | None = None,
     ) -> None:
         """Initialize a PolyData mesh."""
         self.points = np.asarray(points)
@@ -1183,7 +1183,7 @@ class UnstructuredGrid:
         self.cells = np.asarray(cells)
         self.celltypes = np.asarray(celltypes)
         self._point_data = PointData()
-        self._scene_data: dict[str, object] | None = None
+        self._scene_data: dict[str, Any] | None = None
 
     @property
     def point_data(self) -> PointData:


### PR DESCRIPTION
## Summary

This PR fixes mypy type errors related to the `_scene_data` parameter in `PolyData` and `UnstructuredGrid` classes.

## Changes

- Changed type annotation from `dict[str, object]` to `dict[str, Any]` for `_scene_data` parameter
- Added `Any` import from typing module
- Updated both `PolyData.__init__()` and `UnstructuredGrid` class attribute

## Problem

CI lint job was failing with the following mypy errors:
```
src/pyvista_js/mesh.py:542: error: Argument "_scene_data" to "PolyData" has incompatible type "dict[str, object] | dict[str, Sequence[Any]]"; expected "dict[str, object] | None"
src/pyvista_js/mesh.py:671: error: Argument "_scene_data" to "PolyData" has incompatible type "dict[str, object] | dict[str, Sequence[Any]]"; expected "dict[str, object] | None"
...
```

## Solution

Using `Any` type allows for more flexible type checking while maintaining type safety for the internal dictionary structure. This resolves the mypy errors that occurred when `base_scene` dictionary contained mixed types.