### PR TITLE
feat: add triangulate filter using vtk.js TriangleFilter

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -97,6 +97,7 @@ This section provides detailed documentation for the pyvista-js public API.
    pyvista_js.PolyData.fill_holes
    pyvista_js.PolyData.shrink
    pyvista_js.PolyData.texture_map_to_plane
+   pyvista_js.PolyData.triangulate
    pyvista_js.PolyData.tube
 ```
 

--- a/src/pyvista_js/mesh.py
+++ b/src/pyvista_js/mesh.py
@@ -972,6 +972,58 @@ class PolyData:
             _scene_data=base_scene,
         )
 
+    def triangulate(self) -> PolyData:
+        """Triangulate the mesh, converting all polygons to triangles.
+
+        This filter converts all cells in the mesh with more than 3 vertices
+        into triangles. It mirrors the PyVista ``triangulate`` filter API
+        and uses vtk.js's ``vtkTriangleFilter``.
+
+        .. note::
+
+            This filter is useful for ensuring all faces are triangles,
+            which is required for some rendering operations and algorithms.
+
+        Returns
+        -------
+        PolyData
+            A new mesh with all polygons triangulated.
+
+        Examples
+        --------
+        >>> import pyvista_js as pv
+        >>> cube = pv.Cube()
+        >>> triangulated = cube.triangulate()
+        >>> isinstance(triangulated, pv.PolyData)
+        True
+
+        Render the triangulated mesh:
+
+        >>> triangulated.plot()  # doctest: +SKIP
+
+        """
+        base_scene = (
+            dict(self._scene_data)
+            if self._scene_data
+            else {
+                "type": "mesh",
+                "points": self.points.flatten().tolist(),
+            }
+        )
+        base_scene.setdefault("filters", [])
+        filters_list: list[object] = base_scene["filters"]  # type: ignore[assignment]
+        filters_list.append(
+            {
+                "type": "triangulate",
+            },
+        )
+
+        return PolyData(
+            points=self.points,
+            faces=self.faces,
+            _scene_data=base_scene,
+        )
+
     def texture_map_to_plane(self) -> PolyData:
         """Generate texture coordinates by projecting points onto the XY plane.
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -557,6 +557,50 @@ def test_fill_holes_chained_with_shrink() -> None:
     assert scene["filters"][1]["type"] == "fillHoles"
 
 
+def test_triangulate_returns_polydata() -> None:
+    """Test that triangulate returns a PolyData instance."""
+    cube = Cube()
+    triangulated = cube.triangulate()
+    assert isinstance(triangulated, PolyData)
+    assert triangulated.n_points == cube.n_points
+
+
+def test_triangulate_scene_data_contains_filter() -> None:
+    """Test that triangulated mesh scene data includes a triangulate filter."""
+    cube = Cube()
+    triangulated = cube.triangulate()
+    scene = triangulated.to_scene_data()
+    assert "filters" in scene
+    filters = scene["filters"]
+    assert len(filters) >= 1
+    assert filters[-1]["type"] == "triangulate"
+
+
+def test_triangulate_scene_data_has_source_type() -> None:
+    """Test that triangulated mesh scene data preserves the source type."""
+    sphere = Sphere()
+    triangulated = sphere.triangulate()
+    scene = triangulated.to_scene_data()
+    assert scene["type"] == "sphere"
+
+
+def test_triangulate_preserves_faces() -> None:
+    """Test that triangulate preserves face information."""
+    cube = Cube()
+    triangulated = cube.triangulate()
+    assert triangulated.n_faces == cube.n_faces
+
+
+def test_triangulate_can_be_chained() -> None:
+    """Test that triangulate can be chained with other filters."""
+    sphere = Sphere()
+    result = sphere.shrink(shrink_factor=0.8).triangulate()
+    scene = result.to_scene_data()
+    assert len(scene["filters"]) == 2
+    assert scene["filters"][0]["type"] == "shrink"
+    assert scene["filters"][1]["type"] == "triangulate"
+
+
 def test_circle_creation() -> None:
     """Test circle primitive creation."""
     circle = Circle()

--- a/ts/renderer.ts
+++ b/ts/renderer.ts
@@ -889,6 +889,28 @@ function tryFillHolesFilter(current: SourceResult, f: FilterConfig): SourceResul
 }
 
 /**
+ * Try to apply a triangulate filter.
+ * @param current
+ * @param _f
+ * @returns The filtered result with triangles only.
+ */
+function tryTriangulateFilter(current: SourceResult, _f: FilterConfig): SourceResult {
+  return applyTriangulateFilter(current);
+}
+
+/**
+ * Apply a triangle filter to convert polygons to triangles.
+ * @param sourceResult
+ * @returns A {@link SourceResult} with the triangle filter applied.
+ */
+function applyTriangulateFilter(sourceResult: SourceResult): SourceResult {
+  // biome-ignore lint/correctness/noUndeclaredVariables: vtk globals are declared in vtk.d.ts
+  const triangleFilter = vtk.Filters.General.vtkTriangleFilter.newInstance();
+  connectInput(triangleFilter, sourceResult);
+  return { output: triangleFilter, isFilter: true };
+}
+
+/**
  * Map from filter type to its dispatcher function.
  */
 const filterDispatchMap: Record<string, (current: SourceResult, f: FilterConfig) => SourceResult> =
@@ -898,6 +920,7 @@ const filterDispatchMap: Record<string, (current: SourceResult, f: FilterConfig)
     clip: tryClipFilter,
     contour: tryContourFilter,
     fillHoles: tryFillHolesFilter,
+    triangulate: tryTriangulateFilter,
   };
 
 /**

--- a/ts/vtk.d.ts
+++ b/ts/vtk.d.ts
@@ -268,6 +268,7 @@ interface VtkGlobal {
     // biome-ignore lint/style/useNamingConvention: vtk.js API uses PascalCase property names
     General: {
       vtkTubeFilter: VtkNewInstanceFactory<VtkAlgorithm>;
+      vtkTriangleFilter: VtkNewInstanceFactory<VtkAlgorithm>;
       vtkClipClosedSurface?: VtkNewInstanceFactory<VtkAlgorithm>;
       vtkContourTriangulator?: VtkNewInstanceFactory<VtkAlgorithm>;
     };


### PR DESCRIPTION
## Summary

This PR adds a `triangulate()` filter to the `PolyData` class, which converts all polygons to triangles using vtk.js's `vtkTriangleFilter`. This mirrors the PyVista `triangulate` filter API.

## Changes

- **ts/vtk.d.ts**: Added `vtkTriangleFilter` type declaration
- **ts/renderer.ts**: Added `tryTriangulateFilter` and `applyTriangulateFilter` functions
- **src/pyvista_js/mesh.py**: Added `triangulate()` method to `PolyData` class
- **tests/test_mesh.py**: Added comprehensive tests for the triangulate functionality

## Usage

```python
import pyvista_js as pv

# Create a cube (quads)
cube = pv.Cube()

# Triangulate all faces
triangulated = cube.triangulate()

# Can be chained with other filters
result = cube.shrink(shrink_factor=0.8).triangulate()
```

## API Reference

- PyVista triangulate: https://docs.pyvista.org/api/core/_autosummary/pyvista.polydatafilters.triangulate
- VTK.js TriangleFilter: https://kitware.github.io/vtk-js/api/Filters_General_TriangleFilter.html

## Testing

All tests pass:
- `test_triangulate_returns_polydata`
- `test_triangulate_scene_data_contains_filter`
- `test_triangulate_scene_data_has_source_type`
- `test_triangulate_preserves_faces`
- `test_triangulate_can_be_chained`

## Checklist

- [x] TypeScript types updated
- [x] JavaScript filter implementation added
- [x] Python API added
- [x] Tests added
- [x] Build passes
- [x] Lint passes