### PR TITLE
chore: update dependabot to use uv package ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,7 @@ updates:
         patterns:
           - "*"
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary

Update dependabot configuration to use the new uv package ecosystem instead of pip. This enables proper support for uv.lock files.

### Changes

- Changed package-ecosystem from "pip" to "uv"

### Reference

https://docs.astral.sh/uv/guides/integration/dependabot/

> This PR replicates the changes from https://github.com/tkoyama010/pyvista-wasm/pull/67