### PR TITLE
feat: add intro.ipynb notebook and update ReadTheDocs config for JupyterLite

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,14 @@ build:
   tools:
     python: "3.13"
     nodejs: "22"
+  jobs:
+    pre_build:
+      # Convert jupytext .py files to .ipynb
+      - mkdir -p docs/content
+      - jupytext --to notebook jupyterlite/content/intro.py --output docs/content/intro.ipynb
+    post_build:
+      # Build JupyterLite for the docs site
+      - jupyter lite build --contents docs/content --output-dir docs/_build/html/lite
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:


### PR DESCRIPTION
## Summary

This PR adds an `intro.ipynb` notebook to the documentation and updates the ReadTheDocs configuration to properly build JupyterLite.

## Changes

- Added `docs/content/intro.ipynb` - A Jupyter notebook demonstrating basic pyvista-js usage with the bunny mesh example
- Updated `.readthedocs.yaml` - Added `post_build` job to build JupyterLite at `docs/_build/html/lite`
- Updated `.gitignore` - Added exception to allow `intro.ipynb` in `docs/content/`

## Purpose

This enables the intro notebook to be accessible at https://pyvista-js.readthedocs.io/en/latest/lite/lab/index.html

The notebook includes:
- Installation of pyvista-js via micropip
- Basic usage example loading and displaying the Stanford bunny mesh