### PR TITLE
ci: add merge_group trigger to enable GitHub merge queue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
       - 'v*'  # Triggers on version tags like v1.0.0, v0.1.0, etc.
   pull_request:
     branches: [ main ]
+  merge_group:
 
 permissions: {}
 


### PR DESCRIPTION
## Summary

- Add `merge_group` event trigger to the test workflow so CI runs when a PR enters the merge queue
- This is required for GitHub's merge queue feature to work correctly — without it, required status checks are never satisfied in the queue

## Next steps after merging

Enable merge queue in the repository settings:
1. Go to **Settings → Rules → Rulesets** (or **Settings → Branches** for classic branch protection)
2. Add a ruleset for the `main` branch
3. Enable **Require merge queue**
4. Set required status checks: `lint`, `js-check`, and the `test` matrix jobs

## Test plan

- [ ] Confirm CI runs on this PR (pull_request trigger)
- [ ] After merging, add a test PR to the merge queue and verify CI runs under the `merge_group` trigger