### PR TITLE
chore(deps): upgrade GitPython to 3.1.50 to fix GHSA-mv93-w799-cj2w

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,11 @@ test = [
   "pytest-playwright>=0.4.1,<1.0.1",
 ]
 
+[tool.uv]
+constraint-dependencies = [
+  "gitpython>=3.1.50",
+]
+
 [tool.hatch]
 build.targets.wheel.packages = [ "src/pyvista_js" ]
 build.artifacts = [ "src/pyvista_js/templates/renderer.js" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,16 +117,16 @@ test = [
   "pytest-playwright>=0.4.1,<1.0.1",
 ]
 
-[tool.uv]
-constraint-dependencies = [
-  "gitpython>=3.1.50",
-]
-
 [tool.hatch]
 build.targets.wheel.packages = [ "src/pyvista_js" ]
 build.artifacts = [ "src/pyvista_js/templates/renderer.js" ]
 build.hooks.build-scripts.scripts = [
   { commands = [ "npm ci", "npm run build" ], artifacts = [ "src/pyvista_js/templates/renderer.js" ] }
+]
+
+[tool.uv]
+constraint-dependencies = [
+  "gitpython>=3.1.50",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,9 @@ resolution-markers = [
     "python_full_version < '3.14'",
 ]
 
+[manifest]
+constraints = [{ name = "gitpython", specifier = ">=3.1.50" }]
+
 [[package]]
 name = "accessible-pygments"
 version = "0.0.5"
@@ -471,14 +474,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.49"
+version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/63/210aaa302d6a0a78daa67c5c15bbac2cad361722841278b0209b6da20855/gitpython-3.1.49.tar.gz", hash = "sha256:42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1", size = 219367, upload-time = "2026-04-29T00:31:20.478Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/6f/b842bfa6f21d6f87c57f9abf7194225e55279d96d869775e19e9f7236fc5/gitpython-3.1.49-py3-none-any.whl", hash = "sha256:024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c", size = 212190, upload-time = "2026-04-29T00:31:18.412Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `[tool.uv] constraint-dependencies` to pin `gitpython >= 3.1.50` in `pyproject.toml`
- Updates `uv.lock` to resolve GitPython 3.1.49 -> 3.1.50
- Fixes [GHSA-mv93-w799-cj2w](https://github.com/advisories/GHSA-mv93-w799-cj2w): newline injection in `config_writer()` `section` parameter bypasses the CVE-2026-42215 patch, enabling RCE via `core.hooksPath`
- GitPython is a transitive dependency via `streamlit`

Closes Dependabot alert #20.