### PR TITLE
feat: add react-pyvista package

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -55,8 +55,9 @@
       "linter": {
         "rules": {
           "nursery": {
-            // React components do not need explicit return types
+            // React components do not need explicit return types (two sibling rules)
             "useExplicitType": "off",
+            "useExplicitReturnType": "off",
             // Ternary is idiomatic in JSX
             "noTernary": "off",
             // Inline styles are used for the viewer container sizing
@@ -102,7 +103,9 @@
             "noExcessiveLinesPerFile": "off",
             // ++/-- are idiomatic in loop bodies
             "noIncrementDecrement": "off",
-            "noContinue": "off"
+            "noContinue": "off",
+            // Private helpers that operate purely on parameters need not use `this`
+            "useThisInClassMethods": "off"
           },
           "style": {
             "useReadonlyClassProperties": "off",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -7,7 +7,13 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["ts/**/*.ts", "ts/**/*.d.ts", "biome.json"]
+    "includes": [
+      "ts/**/*.ts",
+      "ts/**/*.d.ts",
+      "biome.json",
+      "packages/react-pyvista/src/**/*.ts",
+      "packages/react-pyvista/src/**/*.tsx"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -41,5 +47,69 @@
         "organizeImports": "on"
       }
     }
-  }
+  },
+  "overrides": [
+    {
+      // react-pyvista: relax rules that conflict with React/vtk.js patterns
+      "includes": ["packages/react-pyvista/src/**"],
+      "linter": {
+        "rules": {
+          "nursery": {
+            // React components do not need explicit return types
+            "useExplicitType": "off",
+            // Ternary is idiomatic in JSX
+            "noTernary": "off",
+            // Inline styles are used for the viewer container sizing
+            "noInlineStyles": "off",
+            // `window` is intentional in browser-targeted code; `self` in workers
+            "useGlobalThis": "off",
+            // ++/-- are idiomatic in loop bodies across this package
+            "noIncrementDecrement": "off"
+          },
+          "style": {
+            // Single-line guard returns are idiomatic in React
+            "useBlockStatements": "off"
+          },
+          "performance": {
+            // index.ts is the standard library entry point
+            "noBarrelFile": "off"
+          },
+          "suspicious": {
+            // Pyodide and vtk.js interop requires `any` in several places
+            "noExplicitAny": "off"
+          }
+        }
+      }
+    },
+    {
+      // renderer.ts is an intentionally large vtk.js adapter; complexity is expected
+      "includes": ["packages/react-pyvista/src/renderer.ts"],
+      "linter": {
+        "rules": {
+          "complexity": {
+            "noExcessiveCognitiveComplexity": "off",
+            "noExcessiveLinesPerFunction": "off"
+          },
+          "nursery": {
+            "noExcessiveLinesPerFile": "off",
+            // ++/-- are idiomatic in loop bodies
+            "noIncrementDecrement": "off",
+            "noContinue": "off"
+          },
+          "style": {
+            "useReadonlyClassProperties": "off",
+            "useSingleVarDeclarator": "off"
+          },
+          "suspicious": {
+            // vtk.js global requires `any` bridging
+            "noExplicitAny": "off"
+          },
+          "security": {
+            // CDN URLs are not secrets
+            "noSecrets": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -68,7 +68,13 @@
           },
           "style": {
             // Single-line guard returns are idiomatic in React
-            "useBlockStatements": "off"
+            "useBlockStatements": "off",
+            // Public API types are declared before internal helpers for readability
+            "useExportsLast": "off"
+          },
+          "complexity": {
+            // Hooks accumulate state + effect logic; splitting further reduces readability
+            "noExcessiveLinesPerFunction": "off"
           },
           "performance": {
             // index.ts is the standard library entry point
@@ -76,7 +82,9 @@
           },
           "suspicious": {
             // Pyodide and vtk.js interop requires `any` in several places
-            "noExplicitAny": "off"
+            "noExplicitAny": "off",
+            // This is a Solid.js rule; React uses className/htmlFor intentionally
+            "noReactSpecificProps": "off"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,295 @@
   "requires": true,
   "packages": {
     "": {
+      "workspaces": [
+        "packages/*"
+      ],
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "esbuild": "^0.28",
         "typescript": "^6.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -615,6 +900,1150 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@microsoft/api-extractor": {
+      "version": "7.58.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.58.7.tgz",
+      "integrity": "sha512-yK6OycD46gIzLRpj6ueVUWPk1ACSpkN1LBo05gY1qPTylbWyUCanXfH7+VgkI5LJrJoRSQR5F04XuCffCXLOBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/api-extractor-model": "7.33.8",
+        "@microsoft/tsdoc": "~0.16.0",
+        "@microsoft/tsdoc-config": "~0.18.1",
+        "@rushstack/node-core-library": "5.23.1",
+        "@rushstack/rig-package": "0.7.3",
+        "@rushstack/terminal": "0.24.0",
+        "@rushstack/ts-command-line": "5.3.9",
+        "diff": "~8.0.2",
+        "minimatch": "10.2.3",
+        "resolve": "~1.22.1",
+        "semver": "~7.7.4",
+        "source-map": "~0.6.1",
+        "typescript": "5.9.3"
+      },
+      "bin": {
+        "api-extractor": "bin/api-extractor"
+      }
+    },
+    "node_modules/@microsoft/api-extractor-model": {
+      "version": "7.33.8",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.8.tgz",
+      "integrity": "sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "~0.16.0",
+        "@microsoft/tsdoc-config": "~0.18.1",
+        "@rushstack/node-core-library": "5.23.1"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@microsoft/tsdoc-config": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.18.1.tgz",
+      "integrity": "sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "ajv": "~8.18.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.2"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rushstack/node-core-library": {
+      "version": "5.23.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.23.1.tgz",
+      "integrity": "sha512-wlKmIKIYCKuCASbITvOxLZXepPbwXvrv7S6ig6XNWFchSyhL/E2txmVXspHY49Wu2dzf7nI27a2k/yV5BA3EiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "~8.18.0",
+        "ajv-draft-04": "~1.0.0",
+        "ajv-formats": "~3.0.1",
+        "fs-extra": "~11.3.0",
+        "import-lazy": "~4.0.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.1",
+        "semver": "~7.7.4"
+      },
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rushstack/node-core-library/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@rushstack/problem-matcher": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/problem-matcher/-/problem-matcher-0.2.1.tgz",
+      "integrity": "sha512-gulfhBs6n+I5b7DvjKRfhMGyUejtSgOHTclF/eONr8hcgF1APEDjhxIsfdUYYMzC3rvLwGluqLjbwCFZ8nxrog==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rushstack/rig-package": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.7.3.tgz",
+      "integrity": "sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jju": "~1.4.0",
+        "resolve": "~1.22.1"
+      }
+    },
+    "node_modules/@rushstack/terminal": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.24.0.tgz",
+      "integrity": "sha512-8ZQS4MMaGsv27EXCBiH7WMPkRZrffeDoIevs6z9TM5dzqiY6+Hn4evfK/G+gvgBTjfvfkHIZPQQmalmI2sM4TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rushstack/node-core-library": "5.23.1",
+        "@rushstack/problem-matcher": "0.2.1",
+        "supports-color": "~8.1.1"
+      },
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rushstack/ts-command-line": {
+      "version": "5.3.9",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.9.tgz",
+      "integrity": "sha512-GIHqU+sRGQ3LGWAZu1O+9Yh++qwtyNIIGuNbcWHJjBTm2qRez0cwINUHZ+pQLR8UuzZDcMajrDaNbUYoaL/XtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rushstack/terminal": "0.24.0",
+        "@types/argparse": "1.0.38",
+        "argparse": "~1.0.9",
+        "string-argv": "~0.3.1"
+      }
+    },
+    "node_modules/@types/argparse": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
+      "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
+      "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@vue/shared": "3.5.34",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
+      "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.34",
+        "@vue/shared": "3.5.34"
+      }
+    },
+    "node_modules/@vue/compiler-vue2": {
+      "version": "2.7.16",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
+      "integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "de-indent": "^1.0.2",
+        "he": "^1.2.0"
+      }
+    },
+    "node_modules/@vue/language-core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.0.tgz",
+      "integrity": "sha512-O1ZZFaaBGkKbsRfnVH1ifOK1/1BUkyK+3SQsfnh6PmMmD4qJcTU8godCeA96jjDRTL6zgnK7YzCHfaUlH2r0Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "~2.4.11",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/compiler-vue2": "^2.7.16",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^0.4.9",
+        "minimatch": "^9.0.3",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vue/language-core/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
+      "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/alien-signals": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-0.4.14.tgz",
+      "integrity": "sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.32",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
+      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.361",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
+      "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
@@ -657,6 +2086,697 @@
         "@esbuild/win32-x64": "0.28.0"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/exsolve": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/import-lazy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/kolorist": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/local-pkg": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
+      "integrity": "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.4",
+        "pkg-types": "^2.3.0",
+        "quansync": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
+      "integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mlly/node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
+      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/quansync": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
+    "node_modules/react-pyvista": {
+      "resolved": "packages/react-pyvista",
+      "link": true
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -669,6 +2789,672 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-dts": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-4.5.4.tgz",
+      "integrity": "sha512-d4sOM8M/8z7vRXHHq/ebbblfaxENjogAAekcfcDCCwAyvGqnPrc7f4NZbvItS+g4WTgerW0xDwSz5qz11JT3vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/api-extractor": "^7.50.1",
+        "@rollup/pluginutils": "^5.1.4",
+        "@volar/typescript": "^2.4.11",
+        "@vue/language-core": "2.2.0",
+        "compare-versions": "^6.1.1",
+        "debug": "^4.4.0",
+        "kolorist": "^1.8.0",
+        "local-pkg": "^1.0.0",
+        "magic-string": "^0.30.17"
+      },
+      "peerDependencies": {
+        "typescript": "*",
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "packages/react-pyvista": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@vitejs/plugin-react": "^4.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "typescript": "^6.0",
+        "vite": "^6.0",
+        "vite-plugin-dts": "^4.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@biomejs/biome": "2.4.15",
+        "@biomejs/biome": "^2.4.15",
         "esbuild": "^0.28",
         "typescript": "^6.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "type": "module",
+  "workspaces": ["packages/*"],
   "scripts": {
     "build": "esbuild ts/renderer.ts --bundle --format=iife --outfile=src/pyvista_js/templates/renderer.js --target=es2017",
     "lint": "biome check .",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "private": true,
   "type": "module",
-  "workspaces": ["packages/*"],
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "build": "esbuild ts/renderer.ts --bundle --format=iife --outfile=src/pyvista_js/templates/renderer.js --target=es2017",
     "lint": "biome check .",
@@ -11,7 +13,7 @@
     "watch": "esbuild ts/renderer.ts --bundle --format=iife --outfile=src/pyvista_js/templates/renderer.js --target=es2017 --watch"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.15",
+    "@biomejs/biome": "^2.4.15",
     "esbuild": "^0.28",
     "typescript": "^6.0"
   }

--- a/packages/react-pyvista/package.json
+++ b/packages/react-pyvista/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "react-pyvista",
+  "version": "0.1.0",
+  "description": "React components for PyVista 3D visualization via vtk.js and Pyodide",
+  "type": "module",
+  "main": "dist/react-pyvista.umd.cjs",
+  "module": "dist/react-pyvista.js",
+  "types": "dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/react-pyvista.js",
+      "require": "./dist/react-pyvista.umd.cjs"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "^6.0",
+    "vite": "^6.0",
+    "vite-plugin-dts": "^4.0.0"
+  },
+  "keywords": ["react", "pyvista", "vtk", "3d", "visualization", "webassembly", "pyodide"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tkoyama010/pyvista-js"
+  }
+}

--- a/packages/react-pyvista/src/components/PyVistaProvider.tsx
+++ b/packages/react-pyvista/src/components/PyVistaProvider.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from 'react'
+import { PyVistaContext, type PyVistaConfig } from '../context'
+
+interface PyVistaProviderProps extends PyVistaConfig {
+  children: ReactNode
+}
+
+/**
+ * PyVistaProvider configures global options for all react-pyvista components.
+ *
+ * Wrap your application (or a subtree) with this provider to customise the
+ * vtk.js CDN URL or the Pyodide CDN URL used by usePyVista.
+ *
+ * @example
+ * ```tsx
+ * <PyVistaProvider vtkJsCdnUrl="https://unpkg.com/vtk.js@29.5.0">
+ *   <App />
+ * </PyVistaProvider>
+ * ```
+ */
+export function PyVistaProvider({ vtkJsCdnUrl, pyodideUrl, children }: PyVistaProviderProps) {
+  return (
+    <PyVistaContext.Provider value={{ vtkJsCdnUrl, pyodideUrl }}>
+      {children}
+    </PyVistaContext.Provider>
+  )
+}

--- a/packages/react-pyvista/src/components/PyVistaProvider.tsx
+++ b/packages/react-pyvista/src/components/PyVistaProvider.tsx
@@ -1,8 +1,8 @@
-import type { ReactNode } from 'react'
-import { PyVistaContext, type PyVistaConfig } from '../context'
+import type { ReactNode } from "react";
+import { type PyVistaConfig, PyVistaContext } from "../context";
 
 interface PyVistaProviderProps extends PyVistaConfig {
-  children: ReactNode
+  children: ReactNode;
 }
 
 /**
@@ -23,5 +23,5 @@ export function PyVistaProvider({ vtkJsCdnUrl, pyodideUrl, children }: PyVistaPr
     <PyVistaContext.Provider value={{ vtkJsCdnUrl, pyodideUrl }}>
       {children}
     </PyVistaContext.Provider>
-  )
+  );
 }

--- a/packages/react-pyvista/src/components/PyVistaViewer.tsx
+++ b/packages/react-pyvista/src/components/PyVistaViewer.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useRef, type CSSProperties } from 'react'
+import type { SceneData } from '../types'
+import { loadVtkJs } from '../vtkLoader'
+import { PyVistaRenderer } from '../renderer'
+import { usePyVistaConfig } from '../context'
+
+export interface PyVistaViewerProps {
+  /** Scene data produced by pyvista-js (via usePyVista or fetched from a server). */
+  scene: SceneData
+  /** Width of the viewer. Defaults to 600. */
+  width?: number | string
+  /** Height of the viewer. Defaults to 400. */
+  height?: number | string
+  /** Additional CSS class names for the container element. */
+  className?: string
+  /** Additional inline styles merged onto the container element. */
+  style?: CSSProperties
+}
+
+/**
+ * PyVistaViewer renders a pyvista-js SceneData object using vtk.js.
+ *
+ * vtk.js is loaded automatically from CDN on first render. The viewer
+ * supports full camera interaction (trackball rotate/pan/zoom).
+ *
+ * @example
+ * ```tsx
+ * const { scene } = usePyVista()
+ * // …run code…
+ * return scene ? <PyVistaViewer scene={scene} width={800} height={600} /> : null
+ * ```
+ */
+export function PyVistaViewer({
+  scene,
+  width = 600,
+  height = 400,
+  className,
+  style,
+}: PyVistaViewerProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const rendererRef = useRef<PyVistaRenderer | null>(null)
+  const { vtkJsCdnUrl } = usePyVistaConfig()
+
+  useEffect(() => {
+    let cancelled = false
+
+    loadVtkJs(vtkJsCdnUrl)
+      .then(() => {
+        if (cancelled || !containerRef.current) return
+        rendererRef.current?.destroy()
+        rendererRef.current = new PyVistaRenderer(containerRef.current, scene)
+      })
+      .catch((err: unknown) => {
+        console.error('[react-pyvista] Failed to initialise vtk.js renderer:', err)
+      })
+
+    return () => {
+      cancelled = true
+      rendererRef.current?.destroy()
+      rendererRef.current = null
+    }
+  }, [scene, vtkJsCdnUrl])
+
+  return (
+    <div
+      ref={containerRef}
+      className={className}
+      style={{
+        width,
+        height,
+        position: 'relative',
+        border: '2px solid #333',
+        overflow: 'hidden',
+        ...style,
+      }}
+    />
+  )
+}

--- a/packages/react-pyvista/src/components/PyVistaViewer.tsx
+++ b/packages/react-pyvista/src/components/PyVistaViewer.tsx
@@ -1,20 +1,20 @@
-import { useEffect, useRef, type CSSProperties } from 'react'
-import type { SceneData } from '../types'
-import { loadVtkJs } from '../vtkLoader'
-import { PyVistaRenderer } from '../renderer'
-import { usePyVistaConfig } from '../context'
+import { type CSSProperties, useEffect, useRef } from "react";
+import { usePyVistaConfig } from "../context";
+import { PyVistaRenderer } from "../renderer";
+import type { SceneData } from "../types";
+import { loadVtkJs } from "../vtkLoader";
 
 export interface PyVistaViewerProps {
   /** Scene data produced by pyvista-js (via usePyVista or fetched from a server). */
-  scene: SceneData
+  scene: SceneData;
   /** Width of the viewer. Defaults to 600. */
-  width?: number | string
+  width?: number | string;
   /** Height of the viewer. Defaults to 400. */
-  height?: number | string
+  height?: number | string;
   /** Additional CSS class names for the container element. */
-  className?: string
+  className?: string;
   /** Additional inline styles merged onto the container element. */
-  style?: CSSProperties
+  style?: CSSProperties;
 }
 
 /**
@@ -37,29 +37,30 @@ export function PyVistaViewer({
   className,
   style,
 }: PyVistaViewerProps) {
-  const containerRef = useRef<HTMLDivElement>(null)
-  const rendererRef = useRef<PyVistaRenderer | null>(null)
-  const { vtkJsCdnUrl } = usePyVistaConfig()
+  const containerRef = useRef<HTMLDivElement>(null);
+  const rendererRef = useRef<PyVistaRenderer | null>(null);
+  const { vtkJsCdnUrl } = usePyVistaConfig();
 
   useEffect(() => {
-    let cancelled = false
+    let cancelled = false;
 
     loadVtkJs(vtkJsCdnUrl)
       .then(() => {
-        if (cancelled || !containerRef.current) return
-        rendererRef.current?.destroy()
-        rendererRef.current = new PyVistaRenderer(containerRef.current, scene)
+        if (cancelled || !containerRef.current) return;
+        rendererRef.current?.destroy();
+        rendererRef.current = new PyVistaRenderer(containerRef.current, scene);
       })
       .catch((err: unknown) => {
-        console.error('[react-pyvista] Failed to initialise vtk.js renderer:', err)
-      })
+        // biome-ignore lint/suspicious/noConsole: library-level error reporting
+        console.error("[react-pyvista] Failed to initialise vtk.js renderer:", err);
+      });
 
     return () => {
-      cancelled = true
-      rendererRef.current?.destroy()
-      rendererRef.current = null
-    }
-  }, [scene, vtkJsCdnUrl])
+      cancelled = true;
+      rendererRef.current?.destroy();
+      rendererRef.current = null;
+    };
+  }, [scene, vtkJsCdnUrl]);
 
   return (
     <div
@@ -68,11 +69,11 @@ export function PyVistaViewer({
       style={{
         width,
         height,
-        position: 'relative',
-        border: '2px solid #333',
-        overflow: 'hidden',
+        position: "relative",
+        border: "2px solid #333",
+        overflow: "hidden",
         ...style,
       }}
     />
-  )
+  );
 }

--- a/packages/react-pyvista/src/context.ts
+++ b/packages/react-pyvista/src/context.ts
@@ -1,0 +1,12 @@
+import { createContext, useContext } from 'react'
+
+export interface PyVistaConfig {
+  vtkJsCdnUrl?: string
+  pyodideUrl?: string
+}
+
+export const PyVistaContext = createContext<PyVistaConfig>({})
+
+export function usePyVistaConfig(): PyVistaConfig {
+  return useContext(PyVistaContext)
+}

--- a/packages/react-pyvista/src/context.ts
+++ b/packages/react-pyvista/src/context.ts
@@ -1,12 +1,12 @@
-import { createContext, useContext } from 'react'
+import { createContext, useContext } from "react";
 
 export interface PyVistaConfig {
-  vtkJsCdnUrl?: string
-  pyodideUrl?: string
+  vtkJsCdnUrl?: string;
+  pyodideUrl?: string;
 }
 
-export const PyVistaContext = createContext<PyVistaConfig>({})
+export const PyVistaContext = createContext<PyVistaConfig>({});
 
 export function usePyVistaConfig(): PyVistaConfig {
-  return useContext(PyVistaContext)
+  return useContext(PyVistaContext);
 }

--- a/packages/react-pyvista/src/hooks/usePyVista.ts
+++ b/packages/react-pyvista/src/hooks/usePyVista.ts
@@ -1,38 +1,38 @@
-import { useState, useCallback, useRef, useEffect } from 'react'
-import type { SceneData } from '../types'
-import { usePyVistaConfig } from '../context'
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usePyVistaConfig } from "../context";
+import type { SceneData } from "../types";
 
 export interface UsePyVistaOptions {
   /** Additional Python packages to install via micropip alongside pyvista-js. */
-  packages?: string[]
+  packages?: string[];
 }
 
 export interface UsePyVistaResult {
   /** Run a Python code string. The code should call plotter.show() to emit a scene. */
-  runCode: (code: string) => Promise<void>
+  runCode: (code: string) => Promise<void>;
   /** The most recently captured SceneData, or null before the first run. */
-  scene: SceneData | null
+  scene: SceneData | null;
   /** True while Pyodide or a Python run is in progress. */
-  isLoading: boolean
+  isLoading: boolean;
   /** True once Pyodide and pyvista-js are fully initialised. */
-  isReady: boolean
+  isReady: boolean;
   /** The last error message, or null if there is none. */
-  error: string | null
+  error: string | null;
   /** Accumulated stdout text from the last run. */
-  stdout: string
+  stdout: string;
 }
 
 type WorkerResponse =
-  | { type: 'ready' }
-  | { type: 'scene'; id: string; data: SceneData }
-  | { type: 'error'; id?: string; message: string }
-  | { type: 'stdout'; text: string }
-  | { type: 'stderr'; text: string }
+  | { type: "ready" }
+  | { type: "scene"; id: string; data: SceneData }
+  | { type: "error"; id?: string; message: string }
+  | { type: "stdout"; text: string }
+  | { type: "stderr"; text: string };
 
-let _runIdCounter = 0
+let _runIdCounter = 0;
 function nextRunId(): string {
-  _runIdCounter++
-  return String(_runIdCounter)
+  _runIdCounter++;
+  return String(_runIdCounter);
 }
 
 /**
@@ -59,95 +59,92 @@ function nextRunId(): string {
  * ```
  */
 export function usePyVista(options: UsePyVistaOptions = {}): UsePyVistaResult {
-  const { pyodideUrl } = usePyVistaConfig()
+  const { pyodideUrl } = usePyVistaConfig();
 
-  const [scene, setScene] = useState<SceneData | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const [isReady, setIsReady] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [stdout, setStdout] = useState('')
+  const [scene, setScene] = useState<SceneData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isReady, setIsReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [stdout, setStdout] = useState("");
 
-  const workerRef = useRef<Worker | null>(null)
+  const workerRef = useRef<Worker | null>(null);
   // Map from run-id → { resolve, reject } for the pending Promise
   const pendingRef = useRef<Map<string, { resolve: () => void; reject: (e: Error) => void }>>(
     new Map(),
-  )
+  );
 
-  // Initialise worker once
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Pyodide initialises once on mount; re-running on URL/package changes is not supported.
   useEffect(() => {
-    const worker = new Worker(
-      new URL('../workers/pyodide.worker.ts', import.meta.url),
-      { type: 'module' },
-    )
-    workerRef.current = worker
+    const worker = new Worker(new URL("../workers/pyodide.worker.ts", import.meta.url), {
+      type: "module",
+    });
+    workerRef.current = worker;
 
-    worker.addEventListener('message', (e: MessageEvent<WorkerResponse>) => {
-      const msg = e.data
+    worker.addEventListener("message", (e: MessageEvent<WorkerResponse>) => {
+      const msg = e.data;
       switch (msg.type) {
-        case 'ready':
-          setIsReady(true)
-          setIsLoading(false)
-          break
+        case "ready":
+          setIsReady(true);
+          setIsLoading(false);
+          break;
 
-        case 'scene': {
-          setScene(msg.data)
-          setIsLoading(false)
-          pendingRef.current.get(msg.id)?.resolve()
-          pendingRef.current.delete(msg.id)
-          break
+        case "scene": {
+          setScene(msg.data);
+          setIsLoading(false);
+          pendingRef.current.get(msg.id)?.resolve();
+          pendingRef.current.delete(msg.id);
+          break;
         }
 
-        case 'error': {
-          setError(msg.message)
-          setIsLoading(false)
+        case "error": {
+          setError(msg.message);
+          setIsLoading(false);
           if (msg.id) {
-            pendingRef.current.get(msg.id)?.reject(new Error(msg.message))
-            pendingRef.current.delete(msg.id)
+            pendingRef.current.get(msg.id)?.reject(new Error(msg.message));
+            pendingRef.current.delete(msg.id);
           }
-          break
+          break;
         }
 
-        case 'stdout':
-          setStdout((prev) => prev + msg.text)
-          break
+        case "stdout":
+          setStdout((prev) => prev + msg.text);
+          break;
 
-        case 'stderr':
-          setStdout((prev) => prev + msg.text)
-          break
+        case "stderr":
+          setStdout((prev) => prev + msg.text);
+          break;
+
+        default:
+          break;
       }
-    })
+    });
 
     worker.postMessage({
-      type: 'init',
+      type: "init",
       packages: options.packages ?? [],
       pyodideUrl,
-    })
+    });
 
     return () => {
-      worker.terminate()
-      workerRef.current = null
-    }
-    // Intentionally running only on mount; options changes are not hot-reloaded.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+      worker.terminate();
+      workerRef.current = null;
+    };
+  }, []);
 
-  const runCode = useCallback(
-    (code: string): Promise<void> => {
-      const worker = workerRef.current
-      if (!worker) return Promise.reject(new Error('Worker not initialised'))
+  const runCode = useCallback((code: string): Promise<void> => {
+    const worker = workerRef.current;
+    if (!worker) return Promise.reject(new Error("Worker not initialised"));
 
-      const id = nextRunId()
-      setIsLoading(true)
-      setError(null)
-      setStdout('')
+    const id = nextRunId();
+    setIsLoading(true);
+    setError(null);
+    setStdout("");
 
-      return new Promise<void>((resolve, reject) => {
-        pendingRef.current.set(id, { resolve, reject })
-        worker.postMessage({ type: 'run', id, code })
-      })
-    },
-    [],
-  )
+    return new Promise<void>((resolve, reject) => {
+      pendingRef.current.set(id, { resolve, reject });
+      worker.postMessage({ type: "run", id, code });
+    });
+  }, []);
 
-  return { runCode, scene, isLoading, isReady, error, stdout }
+  return { runCode, scene, isLoading, isReady, error, stdout };
 }

--- a/packages/react-pyvista/src/hooks/usePyVista.ts
+++ b/packages/react-pyvista/src/hooks/usePyVista.ts
@@ -1,0 +1,153 @@
+import { useState, useCallback, useRef, useEffect } from 'react'
+import type { SceneData } from '../types'
+import { usePyVistaConfig } from '../context'
+
+export interface UsePyVistaOptions {
+  /** Additional Python packages to install via micropip alongside pyvista-js. */
+  packages?: string[]
+}
+
+export interface UsePyVistaResult {
+  /** Run a Python code string. The code should call plotter.show() to emit a scene. */
+  runCode: (code: string) => Promise<void>
+  /** The most recently captured SceneData, or null before the first run. */
+  scene: SceneData | null
+  /** True while Pyodide or a Python run is in progress. */
+  isLoading: boolean
+  /** True once Pyodide and pyvista-js are fully initialised. */
+  isReady: boolean
+  /** The last error message, or null if there is none. */
+  error: string | null
+  /** Accumulated stdout text from the last run. */
+  stdout: string
+}
+
+type WorkerResponse =
+  | { type: 'ready' }
+  | { type: 'scene'; id: string; data: SceneData }
+  | { type: 'error'; id?: string; message: string }
+  | { type: 'stdout'; text: string }
+  | { type: 'stderr'; text: string }
+
+let _runIdCounter = 0
+function nextRunId(): string {
+  _runIdCounter++
+  return String(_runIdCounter)
+}
+
+/**
+ * usePyVista — run pyvista-js Python code in a Pyodide Web Worker and
+ * receive the rendered SceneData for display in PyVistaViewer.
+ *
+ * @example
+ * ```tsx
+ * function App() {
+ *   const { runCode, scene, isLoading } = usePyVista()
+ *
+ *   useEffect(() => {
+ *     runCode(`
+ * import pyvista_js as pv
+ * pl = pv.Plotter()
+ * pl.add_mesh(pv.Sphere(), color='red')
+ * pl.show()
+ *     `)
+ *   }, [])
+ *
+ *   if (isLoading) return <p>Loading…</p>
+ *   return scene ? <PyVistaViewer scene={scene} /> : null
+ * }
+ * ```
+ */
+export function usePyVista(options: UsePyVistaOptions = {}): UsePyVistaResult {
+  const { pyodideUrl } = usePyVistaConfig()
+
+  const [scene, setScene] = useState<SceneData | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isReady, setIsReady] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [stdout, setStdout] = useState('')
+
+  const workerRef = useRef<Worker | null>(null)
+  // Map from run-id → { resolve, reject } for the pending Promise
+  const pendingRef = useRef<Map<string, { resolve: () => void; reject: (e: Error) => void }>>(
+    new Map(),
+  )
+
+  // Initialise worker once
+  useEffect(() => {
+    const worker = new Worker(
+      new URL('../workers/pyodide.worker.ts', import.meta.url),
+      { type: 'module' },
+    )
+    workerRef.current = worker
+
+    worker.addEventListener('message', (e: MessageEvent<WorkerResponse>) => {
+      const msg = e.data
+      switch (msg.type) {
+        case 'ready':
+          setIsReady(true)
+          setIsLoading(false)
+          break
+
+        case 'scene': {
+          setScene(msg.data)
+          setIsLoading(false)
+          pendingRef.current.get(msg.id)?.resolve()
+          pendingRef.current.delete(msg.id)
+          break
+        }
+
+        case 'error': {
+          setError(msg.message)
+          setIsLoading(false)
+          if (msg.id) {
+            pendingRef.current.get(msg.id)?.reject(new Error(msg.message))
+            pendingRef.current.delete(msg.id)
+          }
+          break
+        }
+
+        case 'stdout':
+          setStdout((prev) => prev + msg.text)
+          break
+
+        case 'stderr':
+          setStdout((prev) => prev + msg.text)
+          break
+      }
+    })
+
+    worker.postMessage({
+      type: 'init',
+      packages: options.packages ?? [],
+      pyodideUrl,
+    })
+
+    return () => {
+      worker.terminate()
+      workerRef.current = null
+    }
+    // Intentionally running only on mount; options changes are not hot-reloaded.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const runCode = useCallback(
+    (code: string): Promise<void> => {
+      const worker = workerRef.current
+      if (!worker) return Promise.reject(new Error('Worker not initialised'))
+
+      const id = nextRunId()
+      setIsLoading(true)
+      setError(null)
+      setStdout('')
+
+      return new Promise<void>((resolve, reject) => {
+        pendingRef.current.set(id, { resolve, reject })
+        worker.postMessage({ type: 'run', id, code })
+      })
+    },
+    [],
+  )
+
+  return { runCode, scene, isLoading, isReady, error, stdout }
+}

--- a/packages/react-pyvista/src/index.ts
+++ b/packages/react-pyvista/src/index.ts
@@ -1,0 +1,24 @@
+export { PyVistaProvider } from './components/PyVistaProvider'
+export { PyVistaViewer } from './components/PyVistaViewer'
+export type { PyVistaViewerProps } from './components/PyVistaViewer'
+
+export { usePyVista } from './hooks/usePyVista'
+export type { UsePyVistaOptions, UsePyVistaResult } from './hooks/usePyVista'
+
+export type {
+  SceneData,
+  ActorConfig,
+  SourceConfig,
+  LightConfig,
+  CameraConfig,
+  TextActorConfig,
+  FilterConfig,
+  NormalsConfig,
+  PointDataArray,
+  EdgesConfig,
+  PbrConfig,
+  TextureConfig,
+} from './types'
+
+export { DEFAULT_VTK_CDN, loadVtkJs } from './vtkLoader'
+export type { PyVistaConfig } from './context'

--- a/packages/react-pyvista/src/index.ts
+++ b/packages/react-pyvista/src/index.ts
@@ -1,24 +1,21 @@
-export { PyVistaProvider } from './components/PyVistaProvider'
-export { PyVistaViewer } from './components/PyVistaViewer'
-export type { PyVistaViewerProps } from './components/PyVistaViewer'
-
-export { usePyVista } from './hooks/usePyVista'
-export type { UsePyVistaOptions, UsePyVistaResult } from './hooks/usePyVista'
-
+export { PyVistaProvider } from "./components/PyVistaProvider";
+export type { PyVistaViewerProps } from "./components/PyVistaViewer";
+export { PyVistaViewer } from "./components/PyVistaViewer";
+export type { PyVistaConfig } from "./context";
+export type { UsePyVistaOptions, UsePyVistaResult } from "./hooks/usePyVista";
+export { usePyVista } from "./hooks/usePyVista";
 export type {
-  SceneData,
   ActorConfig,
-  SourceConfig,
-  LightConfig,
   CameraConfig,
-  TextActorConfig,
-  FilterConfig,
-  NormalsConfig,
-  PointDataArray,
   EdgesConfig,
+  FilterConfig,
+  LightConfig,
+  NormalsConfig,
   PbrConfig,
+  PointDataArray,
+  SceneData,
+  SourceConfig,
+  TextActorConfig,
   TextureConfig,
-} from './types'
-
-export { DEFAULT_VTK_CDN, loadVtkJs } from './vtkLoader'
-export type { PyVistaConfig } from './context'
+} from "./types";
+export { DEFAULT_VTK_CDN, loadVtkJs } from "./vtkLoader";

--- a/packages/react-pyvista/src/renderer.ts
+++ b/packages/react-pyvista/src/renderer.ts
@@ -1,0 +1,844 @@
+import type {
+  SceneData,
+  ActorConfig,
+  SourceConfig,
+  LightConfig,
+  CameraConfig,
+  TextActorConfig,
+  FilterConfig,
+  NormalsConfig,
+  PointDataArray,
+  PbrConfig,
+  TextureConfig,
+} from './types'
+
+// Constants — mirror pyvista-js/ts/renderer.ts
+const XYZ_COMPONENTS = 3
+const UV_COMPONENTS = 2
+const DEFAULT_WIDTH = 600
+const DEFAULT_HEIGHT = 400
+const COLOR_BYTE_SCALE = 255
+const PERCENT = 100
+const DEFAULT_RADIUS = 1
+const DEFAULT_RESOLUTION = 50
+const POINT_SPHERE_RADIUS_SCALE = 0.01
+const DEFAULT_POINT_SIZE = 5
+const PBR_AMBIENT = 0.1
+const PBR_SPECULAR_METALLIC_WEIGHT = 0.75
+const PBR_SPECULAR_BASE = 0.25
+const PBR_SPECULAR_POWER_SCALE = 100
+const PBR_DIFFUSE_BASE = 0.65
+const PBR_DIFFUSE_METALLIC_WEIGHT = 0.35
+const AXES_VIEWPORT_SIZE = 0.15
+const AXES_MIN_PIXEL_SIZE = 100
+const AXES_MAX_PIXEL_SIZE = 300
+const DISK_RADIAL_RESOLUTION = 1
+const TRIANGLE_VERTS = 3
+const TWO_POINTS_XYZ = 6
+const VTK_REPRESENTATION_SURFACE = 2
+const VTK_REPRESENTATION_WIREFRAME = 1
+const VTK_REPRESENTATION_POINTS = 0
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyVtk = any
+
+function getVtk(): AnyVtk {
+  return (window as unknown as { vtk: AnyVtk }).vtk
+}
+
+function at(array: Float32Array | Uint32Array, index: number): number {
+  return array[index] ?? 0
+}
+
+interface SourceResult {
+  output: AnyVtk
+  isFilter: boolean
+}
+
+function getPolyData(sourceResult: SourceResult): AnyVtk {
+  if (sourceResult.isFilter) {
+    sourceResult.output.update()
+    return sourceResult.output.getOutputData()
+  }
+  return sourceResult.output
+}
+
+function connectInput(filter: AnyVtk, sourceResult: SourceResult): void {
+  if (sourceResult.isFilter) {
+    filter.setInputConnection(sourceResult.output.getOutputPort())
+  } else {
+    filter.setInputData(sourceResult.output)
+  }
+}
+
+/**
+ * PyVistaRenderer renders a pyvista-js SceneData object using vtk.js.
+ * vtk.js must already be loaded as a CDN global (window.vtk) before
+ * constructing this class. Use loadVtkJs() to ensure it is ready.
+ */
+export class PyVistaRenderer {
+  private _renderer: AnyVtk
+  private _renderWindow: AnyVtk
+  private _openGlRenderWindow: AnyVtk
+  private _interactor: AnyVtk
+  private _container: HTMLElement
+
+  constructor(container: HTMLElement, sceneData: SceneData) {
+    this._container = container
+    const vtk = getVtk()
+
+    this._renderer = vtk.Rendering.Core.vtkRenderer.newInstance()
+    const bg = sceneData.background
+    this._renderer.setBackground(bg[0], bg[1], bg[2])
+
+    this._renderWindow = vtk.Rendering.Core.vtkRenderWindow.newInstance()
+    this._renderWindow.addRenderer(this._renderer)
+
+    this._openGlRenderWindow = vtk.Rendering.OpenGL.vtkRenderWindow.newInstance()
+    this._renderWindow.addView(this._openGlRenderWindow)
+    this._openGlRenderWindow.setContainer(container)
+
+    const bbox = container.getBoundingClientRect()
+    this._openGlRenderWindow.setSize(
+      bbox.width || DEFAULT_WIDTH,
+      bbox.height || DEFAULT_HEIGHT,
+    )
+
+    const interactorStyle =
+      vtk.Interaction.Style.vtkInteractorStyleTrackballCamera.newInstance()
+    this._interactor = vtk.Rendering.Core.vtkRenderWindowInteractor.newInstance()
+    this._interactor.setInteractorStyle(interactorStyle)
+    this._interactor.setView(this._openGlRenderWindow)
+    this._interactor.initialize()
+    this._interactor.bindEvents(container)
+
+    if (sceneData.lightingMode === null && sceneData.lights.length === 0) {
+      this._renderer.removeAllLights()
+      this._renderer.setAutomaticLightCreation(false)
+    } else {
+      this._setupLights(sceneData.lights)
+    }
+
+    for (const [index, actorConfig] of sceneData.actors.entries()) {
+      this._setupActor(actorConfig, index)
+    }
+
+    if (sceneData.textActors) {
+      for (const textConfig of sceneData.textActors) {
+        this._setupTextActor(textConfig)
+      }
+    }
+
+    if (sceneData.axes) {
+      this._setupAxes()
+    }
+
+    this._renderer.resetCamera()
+    if (sceneData.camera) {
+      this._setupCamera(sceneData.camera)
+    }
+
+    this._renderWindow.render()
+  }
+
+  destroy(): void {
+    try {
+      this._interactor.unbindEvents?.(this._container)
+    } catch {
+      // ignore — not all vtk.js versions expose unbindEvents
+    }
+    const canvas = this._container.querySelector('canvas')
+    canvas?.remove()
+  }
+
+  private _setupLights(lights: LightConfig[]): void {
+    if (lights.length === 0) return
+    const vtk = getVtk()
+    this._renderer.removeAllLights()
+    this._renderer.setAutomaticLightCreation(false)
+    const typeMap: Record<string, string> = {
+      scene: 'setLightTypeToSceneLight',
+      camera: 'setLightTypeToCameraLight',
+      head: 'setLightTypeToHeadLight',
+    }
+    for (const cfg of lights) {
+      const light = vtk.Rendering.Core.vtkLight.newInstance()
+      const setter = typeMap[cfg.type] ?? 'setLightTypeToSceneLight'
+      const setterFn = light[setter]
+      if (typeof setterFn === 'function') {
+        (setterFn as () => void).call(light)
+      }
+      light.setPosition(cfg.position[0], cfg.position[1], cfg.position[2])
+      light.setFocalPoint(cfg.focalPoint[0], cfg.focalPoint[1], cfg.focalPoint[2])
+      light.setColor(cfg.color[0], cfg.color[1], cfg.color[2])
+      light.setIntensity(cfg.intensity)
+      light.setPositional(cfg.positional)
+      light.setConeAngle(cfg.coneAngle)
+      light.setExponent(cfg.coneFalloff)
+      light.setAttenuationValues(
+        cfg.attenuationValues[0],
+        cfg.attenuationValues[1],
+        cfg.attenuationValues[2],
+      )
+      this._renderer.addLight(light)
+    }
+  }
+
+  private _createSource(cfg: SourceConfig): SourceResult | undefined {
+    const vtk = getVtk()
+    switch (cfg.type) {
+      case 'sphere':
+        return this._createSphereSource(cfg)
+      case 'cone':
+        return {
+          output: vtk.Filters.Sources.vtkConeSource.newInstance({
+            height: cfg.height,
+            radius: cfg.radius,
+            resolution: cfg.resolution,
+          }),
+          isFilter: true,
+        }
+      case 'cube':
+        return {
+          output: vtk.Filters.Sources.vtkCubeSource.newInstance({
+            xLength: cfg.xLength,
+            yLength: cfg.yLength,
+            zLength: cfg.zLength,
+          }),
+          isFilter: false,
+        }
+      case 'cylinder':
+        return {
+          output: vtk.Filters.Sources.vtkCylinderSource.newInstance({
+            height: cfg.height,
+            radius: cfg.radius,
+            resolution: cfg.resolution,
+          }),
+          isFilter: true,
+        }
+      case 'disk':
+        return this._createDiskSource(cfg)
+      case 'circle':
+        return this._createDiskSource({
+          type: 'disk',
+          innerRadius: 0,
+          outerRadius: cfg.radius ?? DEFAULT_RADIUS,
+          resolution: cfg.resolution ?? DEFAULT_RESOLUTION,
+        })
+      case 'arrow':
+        return {
+          output: vtk.Filters.Sources.vtkArrowSource.newInstance({
+            tipLength: cfg.tipLength,
+            tipRadius: cfg.tipRadius,
+            shaftRadius: cfg.shaftRadius,
+          }),
+          isFilter: true,
+        }
+      case 'line':
+        return {
+          output: vtk.Filters.Sources.vtkLineSource.newInstance({
+            point1: cfg.point1,
+            point2: cfg.point2,
+          }),
+          isFilter: true,
+        }
+      case 'plane': {
+        const source = vtk.Filters.Sources.vtkPlaneSource.newInstance({
+          origin: cfg.origin,
+        })
+        if (cfg.normal) {
+          source.setNormal?.(cfg.normal[0], cfg.normal[1], cfg.normal[2])
+        }
+        return { output: source, isFilter: true }
+      }
+      case 'mesh':
+        return this._createMeshSource(cfg)
+      case 'points':
+        return this._createPointsSource(cfg)
+      case 'plyReader':
+      case 'stlReader':
+      case 'objReader':
+      case 'vtkReader':
+        return this._createReaderSource(cfg)
+      default:
+        return undefined
+    }
+  }
+
+  private _createSphereSource(cfg: SourceConfig): SourceResult {
+    const vtk = getVtk()
+    const source = vtk.Filters.Sources.vtkSphereSource.newInstance({
+      center: cfg.center,
+      radius: cfg.radius,
+      thetaResolution: cfg.thetaResolution,
+      phiResolution: cfg.phiResolution,
+    })
+    const texMap = vtk.Filters.Texture.vtkTextureMapToSphere.newInstance()
+    texMap.setInputConnection(source.getOutputPort())
+    return { output: texMap, isFilter: true }
+  }
+
+  private _createDiskSource(cfg: SourceConfig): SourceResult {
+    const vtk = getVtk()
+    const diskFactory = vtk.Filters.Sources.vtkDiskSource
+    const source = diskFactory
+      ? diskFactory.newInstance({
+          innerRadius: cfg.innerRadius,
+          outerRadius: cfg.outerRadius,
+          radialResolution: DISK_RADIAL_RESOLUTION,
+          circumferentialResolution: cfg.resolution,
+        })
+      : undefined
+    return {
+      output: source ?? vtk.Common.DataModel.vtkPolyData.newInstance(),
+      isFilter: true,
+    }
+  }
+
+  private _createMeshSource(cfg: SourceConfig): SourceResult {
+    const vtk = getVtk()
+    const polydata = vtk.Common.DataModel.vtkPolyData.newInstance()
+    const pointsArray = Float32Array.from(cfg.points ?? [])
+    const vtkPts = vtk.Common.Core.vtkPoints.newInstance()
+    vtkPts.setData(pointsArray, XYZ_COMPONENTS)
+    polydata.setPoints(vtkPts)
+    if (cfg.polys) {
+      polydata.getPolys().setData(Uint32Array.from(cfg.polys))
+    }
+    return { output: polydata, isFilter: false }
+  }
+
+  private _createPointsSource(cfg: SourceConfig): SourceResult {
+    const vtk = getVtk()
+    const polydata = vtk.Common.DataModel.vtkPolyData.newInstance()
+    const pointsArray = Float32Array.from(cfg.points ?? [])
+    const vtkPts = vtk.Common.Core.vtkPoints.newInstance()
+    vtkPts.setData(pointsArray, XYZ_COMPONENTS)
+    polydata.setPoints(vtkPts)
+    return { output: polydata, isFilter: false }
+  }
+
+  private _createReaderSource(cfg: SourceConfig): SourceResult {
+    const vtk = getVtk()
+    const readerMap: Record<string, { factory: AnyVtk; parseMethod: string }> = {
+      plyReader: { factory: vtk.IO.Geometry.vtkPLYReader, parseMethod: 'parseAsArrayBuffer' },
+      stlReader: { factory: vtk.IO.Geometry.vtkSTLReader, parseMethod: 'parseAsArrayBuffer' },
+      objReader: { factory: vtk.IO.Misc.vtkOBJReader, parseMethod: 'parseAsText' },
+      vtkReader: { factory: vtk.IO.Legacy.vtkPolyDataReader, parseMethod: 'parseAsText' },
+    }
+    const entry = readerMap[cfg.type]
+    if (!entry) throw new Error(`Unknown reader type: ${cfg.type}`)
+    const bytes = Uint8Array.from(atob(cfg.data ?? ''), (char) => char.codePointAt(0) ?? 0)
+    const reader = entry.factory.newInstance()
+    if (entry.parseMethod === 'parseAsText') {
+      reader.parseAsText(new TextDecoder().decode(bytes))
+    } else {
+      reader.parseAsArrayBuffer(new Uint8Array(bytes).buffer)
+    }
+    return { output: reader, isFilter: true }
+  }
+
+  private _injectPointData(polydata: AnyVtk, pointDataArrays: PointDataArray[] | undefined): void {
+    if (!pointDataArrays) return
+    const vtk = getVtk()
+    for (const array of pointDataArrays) {
+      const dataArray = vtk.Common.Core.vtkDataArray.newInstance({
+        numberOfComponents: array.numberOfComponents,
+        values: Float32Array.from(array.values),
+        name: array.name,
+      })
+      polydata.getPointData().addArray(dataArray)
+    }
+  }
+
+  private _injectTcoords(polydata: AnyVtk, tCoords: number[] | undefined): void {
+    if (!tCoords) return
+    const vtk = getVtk()
+    const tcArray = vtk.Common.Core.vtkDataArray.newInstance({
+      numberOfComponents: UV_COMPONENTS,
+      values: Float32Array.from(tCoords),
+      name: 'TextureCoordinates',
+    })
+    polydata.getPointData().setTcoords(tcArray)
+  }
+
+  private _setupNormals(sourceResult: SourceResult, normalsConfig: NormalsConfig | undefined): SourceResult {
+    if (!normalsConfig) return sourceResult
+    const vtk = getVtk()
+    const normals = vtk.Filters.Core.vtkPolyDataNormals.newInstance()
+    normals.setComputePointNormals?.(normalsConfig.computePointNormals)
+    normals.setComputeCellNormals?.(normalsConfig.computeCellNormals)
+    connectInput(normals, sourceResult)
+    return { output: normals, isFilter: true }
+  }
+
+  private _applyFilters(sourceResult: SourceResult, filters: FilterConfig[]): SourceResult {
+    let current = sourceResult
+    for (const f of filters) {
+      switch (f.type) {
+        case 'shrink':
+          if (f.shrinkFactor !== undefined) current = this._applyShrinkFilter(current, f.shrinkFactor)
+          break
+        case 'tube':
+          if (f.radius !== undefined && f.numberOfSides !== undefined)
+            current = this._applyTubeFilter(current, f.radius, f.numberOfSides)
+          break
+        case 'clip':
+          if (f.normal && f.origin && f.invert !== undefined)
+            current = this._applyClipFilter(current, f.normal, f.origin, f.invert)
+          break
+        case 'contour':
+          if (f.values && f.scalarName && f.scalarData)
+            current = this._applyContourFilter(current, f.values, f.scalarName, f.scalarData)
+          break
+        case 'fillHoles':
+          if (f.holeSize !== undefined) current = this._applyFillHolesFilter(current, f.holeSize)
+          break
+      }
+    }
+    return current
+  }
+
+  private _applyPbr(actor: AnyVtk, pbr: PbrConfig | undefined): void {
+    if (!pbr) return
+    const m = pbr.metallic
+    const r = pbr.roughness
+    actor.getProperty().setInterpolationToPhong()
+    actor.getProperty().setMetallic(m)
+    actor.getProperty().setRoughness(r)
+    actor.getProperty().setAmbient(PBR_AMBIENT)
+    actor.getProperty().setSpecular(PBR_SPECULAR_METALLIC_WEIGHT * m + PBR_SPECULAR_BASE)
+    actor.getProperty().setSpecularPower(Math.max(1, PBR_SPECULAR_POWER_SCALE * (1 - r)))
+    actor.getProperty().setDiffuse(PBR_DIFFUSE_BASE + PBR_DIFFUSE_METALLIC_WEIGHT * (1 - m))
+  }
+
+  private _applyTexture(actor: AnyVtk, textureCfg: TextureConfig | undefined): void {
+    if (!textureCfg) return
+    const vtk = getVtk()
+    const texture = vtk.Rendering.Core.vtkTexture.newInstance()
+    texture.setInterpolate(true)
+    actor.addTexture(texture)
+    const img = new Image()
+    img.crossOrigin = 'anonymous'
+    img.addEventListener('load', () => {
+      texture.setImage(img)
+      this._renderWindow.render()
+    })
+    img.src = textureCfg.url
+  }
+
+  private _applyActorStyle(actor: AnyVtk, cfg: ActorConfig): void {
+    const styleMap: Record<string, number> = {
+      surface: VTK_REPRESENTATION_SURFACE,
+      wireframe: VTK_REPRESENTATION_WIREFRAME,
+      points: VTK_REPRESENTATION_POINTS,
+    }
+    const rep = styleMap[cfg.style]
+    if (rep !== undefined) actor.getProperty().setRepresentation(rep)
+    if (cfg.shading === 'gouraud') {
+      actor.getProperty().setInterpolationToGouraud()
+    } else if (cfg.shading === 'flat') {
+      actor.getProperty().setInterpolationToFlat()
+    }
+    if (cfg.edges) {
+      actor.getProperty().setEdgeVisibility(true)
+      actor.getProperty().setEdgeColor(
+        cfg.edges.color[0],
+        cfg.edges.color[1],
+        cfg.edges.color[2],
+      )
+    }
+  }
+
+  private _applyPointStyle(actor: AnyVtk, mapper: AnyVtk, cfg: ActorConfig): void {
+    if (cfg.actorType !== 'points') return
+    if (cfg.renderPointsAsSpheres && mapper.setRadius) {
+      mapper.setRadius((cfg.pointSize ?? DEFAULT_POINT_SIZE) * POINT_SPHERE_RADIUS_SCALE)
+    } else {
+      actor.getProperty().setPointSize(cfg.pointSize ?? DEFAULT_POINT_SIZE)
+      actor.getProperty().setRepresentationToPoints()
+    }
+  }
+
+  private _createMapper(mapperInput: SourceResult, cfg: ActorConfig): AnyVtk {
+    const vtk = getVtk()
+    const mapperClass =
+      cfg.actorType === 'points' && cfg.renderPointsAsSpheres
+        ? vtk.Rendering.Core.vtkSphereMapper
+        : vtk.Rendering.Core.vtkMapper
+    const mapper = mapperClass.newInstance()
+    if (mapperInput.isFilter) {
+      mapper.setInputConnection(mapperInput.output.getOutputPort())
+    } else {
+      mapper.setInputData(mapperInput.output)
+    }
+    return mapper
+  }
+
+  private _setupActor(cfg: ActorConfig, _index: number): void {
+    const vtk = getVtk()
+    const sourceResult = this._createSource(cfg.source)
+    if (!sourceResult?.output) return
+
+    if (cfg.source.pointData ?? cfg.source.tCoords) {
+      const pd = getPolyData(sourceResult)
+      this._injectPointData(pd, cfg.source.pointData)
+      this._injectTcoords(pd, cfg.source.tCoords)
+    }
+
+    let currentResult = sourceResult
+    if (cfg.source.filters && cfg.source.filters.length > 0) {
+      currentResult = this._applyFilters(sourceResult, cfg.source.filters)
+    }
+
+    const mapperInput = this._setupNormals(currentResult, cfg.normals)
+    const mapper = this._createMapper(mapperInput, cfg)
+
+    const actor = vtk.Rendering.Core.vtkActor.newInstance()
+    actor.setMapper(mapper)
+    actor.getProperty().setColor(cfg.color[0], cfg.color[1], cfg.color[2])
+    actor.getProperty().setOpacity(cfg.opacity)
+
+    this._applyActorStyle(actor, cfg)
+    this._applyPbr(actor, cfg.pbr)
+    this._applyPointStyle(actor, mapper, cfg)
+    this._applyTexture(actor, cfg.texture)
+
+    this._renderer.addActor(actor)
+  }
+
+  private _setupCamera(camConfig: CameraConfig): void {
+    const cam = this._renderer.getActiveCamera()
+    if (camConfig.position) {
+      cam.setPosition(camConfig.position[0], camConfig.position[1], camConfig.position[2])
+    }
+    if (camConfig.focalPoint) {
+      cam.setFocalPoint(camConfig.focalPoint[0], camConfig.focalPoint[1], camConfig.focalPoint[2])
+    }
+    if (camConfig.viewUp) {
+      cam.setViewUp(camConfig.viewUp[0], camConfig.viewUp[1], camConfig.viewUp[2])
+    }
+    if (camConfig.viewAngle !== undefined) {
+      cam.setViewAngle(camConfig.viewAngle)
+    }
+    if (camConfig.clippingRange) {
+      cam.setClippingRange(camConfig.clippingRange[0], camConfig.clippingRange[1])
+    }
+    if (camConfig.parallelProjection) {
+      cam.setParallelProjection(true)
+    }
+    if (camConfig.viewVector && camConfig.viewUp) {
+      cam.setPosition(camConfig.viewVector[0], camConfig.viewVector[1], camConfig.viewVector[2])
+      cam.setViewUp(camConfig.viewUp[0], camConfig.viewUp[1], camConfig.viewUp[2])
+      cam.setFocalPoint(0, 0, 0)
+      this._renderer.resetCamera()
+      this._renderer.resetCameraClippingRange()
+    }
+  }
+
+  private _setupAxes(): void {
+    const vtk = getVtk()
+    const axes = vtk.Rendering.Core.vtkAxesActor.newInstance()
+    const orientationWidget = vtk.Interaction.Widgets.vtkOrientationMarkerWidget.newInstance({
+      actor: axes,
+      interactor: this._interactor,
+    })
+    orientationWidget.setEnabled(true)
+    orientationWidget.setViewportCorner(
+      vtk.Interaction.Widgets.vtkOrientationMarkerWidget.Corners.BOTTOM_LEFT,
+    )
+    orientationWidget.setViewportSize(AXES_VIEWPORT_SIZE)
+    orientationWidget.setMinPixelSize(AXES_MIN_PIXEL_SIZE)
+    orientationWidget.setMaxPixelSize(AXES_MAX_PIXEL_SIZE)
+  }
+
+  private _setupTextActor(cfg: TextActorConfig): void {
+    const div = document.createElement('div')
+    div.textContent = cfg.text
+    div.style.position = 'absolute'
+    div.style.left = `${String(cfg.position[0] * PERCENT)}%`
+    div.style.bottom = `${String(cfg.position[1] * PERCENT)}%`
+    const r = Math.round(cfg.color[0] * COLOR_BYTE_SCALE)
+    const g = Math.round(cfg.color[1] * COLOR_BYTE_SCALE)
+    const b = Math.round(cfg.color[2] * COLOR_BYTE_SCALE)
+    div.style.color = `rgba(${String(r)},${String(g)},${String(b)},${String(cfg.opacity)})`
+    div.style.fontSize = `${String(cfg.fontSize)}px`
+    div.style.fontWeight = cfg.bold ? 'bold' : 'normal'
+    div.style.fontStyle = cfg.italic ? 'italic' : 'normal'
+    div.style.pointerEvents = 'none'
+    div.style.zIndex = '10'
+    div.style.whiteSpace = 'pre'
+    div.style.textShadow = '1px 1px 2px rgba(0,0,0,0.8), -1px -1px 2px rgba(0,0,0,0.8)'
+    this._container.append(div)
+  }
+
+  // --- Filter implementations ---
+
+  private _applyShrinkFilter(sourceResult: SourceResult, shrinkFactor: number): SourceResult {
+    const vtk = getVtk()
+    const inputPd = getPolyData(sourceResult)
+    const inPoints = inputPd.getPoints().getData()
+    const polys = inputPd.getPolys().getData()
+    if (polys.length === 0) return sourceResult
+
+    const resultPoints: number[] = []
+    const resultPolys: number[] = []
+    let offset = 0
+    let index = 0
+    while (index < polys.length) {
+      const nVerts = at(polys, index)
+      index++
+      let cx = 0, cy = 0, cz = 0
+      const indices: number[] = []
+      for (let i = 0; i < nVerts; i++) {
+        const vi = at(polys, index + i)
+        indices.push(vi)
+        cx += at(inPoints, vi * XYZ_COMPONENTS)
+        cy += at(inPoints, vi * XYZ_COMPONENTS + 1)
+        cz += at(inPoints, vi * XYZ_COMPONENTS + 2)
+      }
+      cx /= nVerts; cy /= nVerts; cz /= nVerts
+      resultPolys.push(nVerts)
+      for (let k = 0; k < nVerts; k++) {
+        const pi = indices[k] ?? 0
+        const px = at(inPoints, pi * XYZ_COMPONENTS)
+        const py = at(inPoints, pi * XYZ_COMPONENTS + 1)
+        const pz = at(inPoints, pi * XYZ_COMPONENTS + 2)
+        resultPoints.push(
+          cx + (px - cx) * shrinkFactor,
+          cy + (py - cy) * shrinkFactor,
+          cz + (pz - cz) * shrinkFactor,
+        )
+        resultPolys.push(offset + k)
+      }
+      offset += nVerts
+      index += nVerts
+    }
+
+    const outputPd = vtk.Common.DataModel.vtkPolyData.newInstance()
+    outputPd.getPoints().setData(new Float32Array(resultPoints), XYZ_COMPONENTS)
+    outputPd.getPolys().setData(new Uint32Array(resultPolys))
+    return { output: outputPd, isFilter: false }
+  }
+
+  private _applyTubeFilter(sourceResult: SourceResult, radius: number, numberOfSides: number): SourceResult {
+    const vtk = getVtk()
+    const tubeFilter = vtk.Filters.General.vtkTubeFilter.newInstance({ radius, numberOfSides })
+    connectInput(tubeFilter, sourceResult)
+    return { output: tubeFilter, isFilter: true }
+  }
+
+  private _applyClipFilter(
+    sourceResult: SourceResult,
+    normal: [number, number, number],
+    origin: [number, number, number],
+    invert: boolean,
+  ): SourceResult {
+    const vtk = getVtk()
+    const plane = vtk.Common.DataModel.vtkPlane.newInstance()
+    plane.setOrigin(origin[0], origin[1], origin[2])
+    plane.setNormal(normal[0], normal[1], normal[2])
+    const clipFactory = vtk.Filters.General.vtkClipClosedSurface
+    if (clipFactory) {
+      const clipper = clipFactory.newInstance()
+      clipper.setClippingPlanes?.([plane])
+      connectInput(clipper, sourceResult)
+      return { output: clipper, isFilter: true }
+    }
+    return this._applyClipManual(sourceResult, normal, origin, invert)
+  }
+
+  private _applyClipManual(
+    sourceResult: SourceResult,
+    normal: [number, number, number],
+    origin: [number, number, number],
+    invert: boolean,
+  ): SourceResult {
+    const vtk = getVtk()
+    const inputPd = getPolyData(sourceResult)
+    const inPoints = inputPd.getPoints().getData()
+    const polys = inputPd.getPolys().getData()
+    if (polys.length === 0) return sourceResult
+
+    const resultPoints: number[] = []
+    const resultPolys: number[] = []
+    const pointMap = new Map<number, number>()
+    let nextIndex = 0
+    let index = 0
+    while (index < polys.length) {
+      const nVerts = at(polys, index)
+      index++
+      const cellIndices: number[] = []
+      for (let i = 0; i < nVerts; i++) cellIndices.push(at(polys, index + i))
+
+      let cx = 0, cy = 0, cz = 0
+      for (const vi of cellIndices) {
+        cx += at(inPoints, vi * XYZ_COMPONENTS)
+        cy += at(inPoints, vi * XYZ_COMPONENTS + 1)
+        cz += at(inPoints, vi * XYZ_COMPONENTS + 2)
+      }
+      cx /= nVerts; cy /= nVerts; cz /= nVerts
+      const dot = (cx - origin[0]) * normal[0] + (cy - origin[1]) * normal[1] + (cz - origin[2]) * normal[2]
+      const keep = invert ? dot >= 0 : dot <= 0
+
+      if (keep) {
+        resultPolys.push(cellIndices.length)
+        for (const pi of cellIndices) {
+          if (!pointMap.has(pi)) {
+            pointMap.set(pi, nextIndex++)
+            resultPoints.push(
+              at(inPoints, pi * XYZ_COMPONENTS),
+              at(inPoints, pi * XYZ_COMPONENTS + 1),
+              at(inPoints, pi * XYZ_COMPONENTS + 2),
+            )
+          }
+          resultPolys.push(pointMap.get(pi) ?? 0)
+        }
+      }
+      index += nVerts
+    }
+
+    const outputPd = vtk.Common.DataModel.vtkPolyData.newInstance()
+    outputPd.getPoints().setData(new Float32Array(resultPoints), XYZ_COMPONENTS)
+    outputPd.getPolys().setData(new Uint32Array(resultPolys))
+    return { output: outputPd, isFilter: false }
+  }
+
+  private _applyContourFilter(
+    sourceResult: SourceResult,
+    values: number[],
+    scalarName: string,
+    scalarData: number[],
+  ): SourceResult {
+    const vtk = getVtk()
+    const inputPd = getPolyData(sourceResult)
+    const scalars = vtk.Common.Core.vtkDataArray.newInstance({
+      numberOfComponents: 1,
+      values: Float32Array.from(scalarData),
+      name: scalarName,
+    })
+    inputPd.getPointData().addArray(scalars)
+    inputPd.getPointData().setActiveScalars(scalarName)
+
+    const inPoints = inputPd.getPoints().getData()
+    const polys = inputPd.getPolys().getData()
+    const scalarValues = scalars.getData()
+    if (polys.length === 0) return { output: inputPd, isFilter: false }
+
+    const outPoints: number[] = []
+    const outPolys: number[] = []
+    let pointIndex = 0
+    let index = 0
+    while (index < polys.length) {
+      const nVerts = at(polys, index)
+      index++
+      if (nVerts === TRIANGLE_VERTS) {
+        const i0 = at(polys, index), i1 = at(polys, index + 1), i2 = at(polys, index + 2)
+        const s0 = at(scalarValues, i0), s1 = at(scalarValues, i1), s2 = at(scalarValues, i2)
+        const edges: [number, number, number, number][] = [[i0, i1, s0, s1], [i1, i2, s1, s2], [i2, i0, s2, s0]]
+        for (const value of values) {
+          const edgePoints: number[] = []
+          for (const [ai, bi, sa, sb] of edges) {
+            if ((sa <= value && value < sb) || (sb <= value && value < sa)) {
+              const t = (value - sa) / (sb - sa)
+              edgePoints.push(
+                at(inPoints, ai * XYZ_COMPONENTS) + t * (at(inPoints, bi * XYZ_COMPONENTS) - at(inPoints, ai * XYZ_COMPONENTS)),
+                at(inPoints, ai * XYZ_COMPONENTS + 1) + t * (at(inPoints, bi * XYZ_COMPONENTS + 1) - at(inPoints, ai * XYZ_COMPONENTS + 1)),
+                at(inPoints, ai * XYZ_COMPONENTS + 2) + t * (at(inPoints, bi * XYZ_COMPONENTS + 2) - at(inPoints, ai * XYZ_COMPONENTS + 2)),
+              )
+            }
+          }
+          if (edgePoints.length === TWO_POINTS_XYZ) {
+            outPoints.push(...edgePoints)
+            outPolys.push(2, pointIndex, pointIndex + 1)
+            pointIndex += 2
+          }
+        }
+      }
+      index += nVerts
+    }
+
+    const outputPd = vtk.Common.DataModel.vtkPolyData.newInstance()
+    if (outPoints.length > 0) {
+      outputPd.getPoints().setData(new Float32Array(outPoints), XYZ_COMPONENTS)
+      outputPd.getLines().setData(new Uint32Array(outPolys))
+    }
+    return { output: outputPd, isFilter: false }
+  }
+
+  private _applyFillHolesFilter(sourceResult: SourceResult, holeSize: number): SourceResult {
+    const vtk = getVtk()
+    const inputPd = getPolyData(sourceResult)
+    const inPoints = inputPd.getPoints().getData()
+    const polys = inputPd.getPolys().getData()
+    if (polys.length === 0) return sourceResult
+
+    const edgeCount = new Map<string, number>()
+    let index = 0
+    while (index < polys.length) {
+      const nVerts = at(polys, index)
+      index++
+      for (let k = 0; k < nVerts; k++) {
+        const a = at(polys, index + k)
+        const b = at(polys, index + ((k + 1) % nVerts))
+        const key = `${String(Math.min(a, b))}_${String(Math.max(a, b))}`
+        edgeCount.set(key, (edgeCount.get(key) ?? 0) + 1)
+      }
+      index += nVerts
+    }
+
+    const boundaryAdj = new Map<number, number[]>()
+    for (const [key, count] of edgeCount) {
+      if (count !== 1) continue
+      const parts = key.split('_')
+      const a = Number(parts[0]), b = Number(parts[1])
+      ;(boundaryAdj.get(a) ?? boundaryAdj.set(a, []).get(a)!).push(b)
+      ;(boundaryAdj.get(b) ?? boundaryAdj.set(b, []).get(b)!).push(a)
+    }
+    if (boundaryAdj.size === 0) return sourceResult
+
+    const visited = new Set<number>()
+    const loops: number[][] = []
+    for (const startNode of boundaryAdj.keys()) {
+      if (visited.has(startNode)) continue
+      const loop: number[] = []
+      let current = startNode, previous = -1, stuck = false
+      while (!stuck) {
+        visited.add(current)
+        loop.push(current)
+        const neighbors = boundaryAdj.get(current) ?? []
+        let next = -1
+        for (const n of neighbors) {
+          if (n !== previous && !visited.has(n)) { next = n; break }
+        }
+        if (next === -1) { stuck = true } else { previous = current; current = next }
+      }
+      if (loop.length > 2) loops.push(loop)
+    }
+
+    const newPolys: number[] = []
+    for (const loop of loops) {
+      let perimeter = 0
+      for (let k = 0; k < loop.length; k++) {
+        const a = loop[k] ?? 0, b = loop[(k + 1) % loop.length] ?? 0
+        const dx = at(inPoints, b * XYZ_COMPONENTS) - at(inPoints, a * XYZ_COMPONENTS)
+        const dy = at(inPoints, b * XYZ_COMPONENTS + 1) - at(inPoints, a * XYZ_COMPONENTS + 1)
+        const dz = at(inPoints, b * XYZ_COMPONENTS + 2) - at(inPoints, a * XYZ_COMPONENTS + 2)
+        perimeter += Math.hypot(dx, dy, dz)
+      }
+      if (perimeter <= holeSize) {
+        const v0 = loop[0] ?? 0
+        for (let k = 1; k < loop.length - 1; k++) {
+          newPolys.push(TRIANGLE_VERTS, v0, loop[k] ?? 0, loop[k + 1] ?? 0)
+        }
+      }
+    }
+
+    if (newPolys.length === 0) return sourceResult
+    const mergedPolys = new Uint32Array([...polys, ...newPolys])
+    const outputPd = vtk.Common.DataModel.vtkPolyData.newInstance()
+    outputPd.getPoints().setData(new Float32Array(inPoints), XYZ_COMPONENTS)
+    outputPd.getPolys().setData(mergedPolys)
+    return { output: outputPd, isFilter: false }
+  }
+}

--- a/packages/react-pyvista/src/renderer.ts
+++ b/packages/react-pyvista/src/renderer.ts
@@ -1,73 +1,73 @@
 import type {
-  SceneData,
   ActorConfig,
-  SourceConfig,
-  LightConfig,
   CameraConfig,
-  TextActorConfig,
   FilterConfig,
+  LightConfig,
   NormalsConfig,
-  PointDataArray,
   PbrConfig,
+  PointDataArray,
+  SceneData,
+  SourceConfig,
+  TextActorConfig,
   TextureConfig,
-} from './types'
+} from "./types";
 
 // Constants — mirror pyvista-js/ts/renderer.ts
-const XYZ_COMPONENTS = 3
-const UV_COMPONENTS = 2
-const DEFAULT_WIDTH = 600
-const DEFAULT_HEIGHT = 400
-const COLOR_BYTE_SCALE = 255
-const PERCENT = 100
-const DEFAULT_RADIUS = 1
-const DEFAULT_RESOLUTION = 50
-const POINT_SPHERE_RADIUS_SCALE = 0.01
-const DEFAULT_POINT_SIZE = 5
-const PBR_AMBIENT = 0.1
-const PBR_SPECULAR_METALLIC_WEIGHT = 0.75
-const PBR_SPECULAR_BASE = 0.25
-const PBR_SPECULAR_POWER_SCALE = 100
-const PBR_DIFFUSE_BASE = 0.65
-const PBR_DIFFUSE_METALLIC_WEIGHT = 0.35
-const AXES_VIEWPORT_SIZE = 0.15
-const AXES_MIN_PIXEL_SIZE = 100
-const AXES_MAX_PIXEL_SIZE = 300
-const DISK_RADIAL_RESOLUTION = 1
-const TRIANGLE_VERTS = 3
-const TWO_POINTS_XYZ = 6
-const VTK_REPRESENTATION_SURFACE = 2
-const VTK_REPRESENTATION_WIREFRAME = 1
-const VTK_REPRESENTATION_POINTS = 0
+const XYZ_COMPONENTS = 3;
+const UV_COMPONENTS = 2;
+const DEFAULT_WIDTH = 600;
+const DEFAULT_HEIGHT = 400;
+const COLOR_BYTE_SCALE = 255;
+const PERCENT = 100;
+const DEFAULT_RADIUS = 1;
+const DEFAULT_RESOLUTION = 50;
+const POINT_SPHERE_RADIUS_SCALE = 0.01;
+const DEFAULT_POINT_SIZE = 5;
+const PBR_AMBIENT = 0.1;
+const PBR_SPECULAR_METALLIC_WEIGHT = 0.75;
+const PBR_SPECULAR_BASE = 0.25;
+const PBR_SPECULAR_POWER_SCALE = 100;
+const PBR_DIFFUSE_BASE = 0.65;
+const PBR_DIFFUSE_METALLIC_WEIGHT = 0.35;
+const AXES_VIEWPORT_SIZE = 0.15;
+const AXES_MIN_PIXEL_SIZE = 100;
+const AXES_MAX_PIXEL_SIZE = 300;
+const DISK_RADIAL_RESOLUTION = 1;
+const TRIANGLE_VERTS = 3;
+const TWO_POINTS_XYZ = 6;
+const VTK_REPRESENTATION_SURFACE = 2;
+const VTK_REPRESENTATION_WIREFRAME = 1;
+const VTK_REPRESENTATION_POINTS = 0;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyVtk = any
+type AnyVtk = any;
 
 function getVtk(): AnyVtk {
-  return (window as unknown as { vtk: AnyVtk }).vtk
+  return (window as unknown as { vtk: AnyVtk }).vtk;
 }
 
 function at(array: Float32Array | Uint32Array, index: number): number {
-  return array[index] ?? 0
+  return array[index] ?? 0;
 }
 
 interface SourceResult {
-  output: AnyVtk
-  isFilter: boolean
+  output: AnyVtk;
+  isFilter: boolean;
 }
 
 function getPolyData(sourceResult: SourceResult): AnyVtk {
   if (sourceResult.isFilter) {
-    sourceResult.output.update()
-    return sourceResult.output.getOutputData()
+    sourceResult.output.update();
+    return sourceResult.output.getOutputData();
   }
-  return sourceResult.output
+  return sourceResult.output;
 }
 
 function connectInput(filter: AnyVtk, sourceResult: SourceResult): void {
   if (sourceResult.isFilter) {
-    filter.setInputConnection(sourceResult.output.getOutputPort())
+    filter.setInputConnection(sourceResult.output.getOutputPort());
   } else {
-    filter.setInputData(sourceResult.output)
+    filter.setInputData(sourceResult.output);
   }
 }
 
@@ -77,119 +77,115 @@ function connectInput(filter: AnyVtk, sourceResult: SourceResult): void {
  * constructing this class. Use loadVtkJs() to ensure it is ready.
  */
 export class PyVistaRenderer {
-  private _renderer: AnyVtk
-  private _renderWindow: AnyVtk
-  private _openGlRenderWindow: AnyVtk
-  private _interactor: AnyVtk
-  private _container: HTMLElement
+  private _renderer: AnyVtk;
+  private _renderWindow: AnyVtk;
+  private _openGlRenderWindow: AnyVtk;
+  private _interactor: AnyVtk;
+  private _container: HTMLElement;
 
   constructor(container: HTMLElement, sceneData: SceneData) {
-    this._container = container
-    const vtk = getVtk()
+    this._container = container;
+    const vtk = getVtk();
 
-    this._renderer = vtk.Rendering.Core.vtkRenderer.newInstance()
-    const bg = sceneData.background
-    this._renderer.setBackground(bg[0], bg[1], bg[2])
+    this._renderer = vtk.Rendering.Core.vtkRenderer.newInstance();
+    const bg = sceneData.background;
+    this._renderer.setBackground(bg[0], bg[1], bg[2]);
 
-    this._renderWindow = vtk.Rendering.Core.vtkRenderWindow.newInstance()
-    this._renderWindow.addRenderer(this._renderer)
+    this._renderWindow = vtk.Rendering.Core.vtkRenderWindow.newInstance();
+    this._renderWindow.addRenderer(this._renderer);
 
-    this._openGlRenderWindow = vtk.Rendering.OpenGL.vtkRenderWindow.newInstance()
-    this._renderWindow.addView(this._openGlRenderWindow)
-    this._openGlRenderWindow.setContainer(container)
+    this._openGlRenderWindow = vtk.Rendering.OpenGL.vtkRenderWindow.newInstance();
+    this._renderWindow.addView(this._openGlRenderWindow);
+    this._openGlRenderWindow.setContainer(container);
 
-    const bbox = container.getBoundingClientRect()
-    this._openGlRenderWindow.setSize(
-      bbox.width || DEFAULT_WIDTH,
-      bbox.height || DEFAULT_HEIGHT,
-    )
+    const bbox = container.getBoundingClientRect();
+    this._openGlRenderWindow.setSize(bbox.width || DEFAULT_WIDTH, bbox.height || DEFAULT_HEIGHT);
 
-    const interactorStyle =
-      vtk.Interaction.Style.vtkInteractorStyleTrackballCamera.newInstance()
-    this._interactor = vtk.Rendering.Core.vtkRenderWindowInteractor.newInstance()
-    this._interactor.setInteractorStyle(interactorStyle)
-    this._interactor.setView(this._openGlRenderWindow)
-    this._interactor.initialize()
-    this._interactor.bindEvents(container)
+    const interactorStyle = vtk.Interaction.Style.vtkInteractorStyleTrackballCamera.newInstance();
+    this._interactor = vtk.Rendering.Core.vtkRenderWindowInteractor.newInstance();
+    this._interactor.setInteractorStyle(interactorStyle);
+    this._interactor.setView(this._openGlRenderWindow);
+    this._interactor.initialize();
+    this._interactor.bindEvents(container);
 
     if (sceneData.lightingMode === null && sceneData.lights.length === 0) {
-      this._renderer.removeAllLights()
-      this._renderer.setAutomaticLightCreation(false)
+      this._renderer.removeAllLights();
+      this._renderer.setAutomaticLightCreation(false);
     } else {
-      this._setupLights(sceneData.lights)
+      this._setupLights(sceneData.lights);
     }
 
     for (const [index, actorConfig] of sceneData.actors.entries()) {
-      this._setupActor(actorConfig, index)
+      this._setupActor(actorConfig, index);
     }
 
     if (sceneData.textActors) {
       for (const textConfig of sceneData.textActors) {
-        this._setupTextActor(textConfig)
+        this._setupTextActor(textConfig);
       }
     }
 
     if (sceneData.axes) {
-      this._setupAxes()
+      this._setupAxes();
     }
 
-    this._renderer.resetCamera()
+    this._renderer.resetCamera();
     if (sceneData.camera) {
-      this._setupCamera(sceneData.camera)
+      this._setupCamera(sceneData.camera);
     }
 
-    this._renderWindow.render()
+    this._renderWindow.render();
   }
 
   destroy(): void {
     try {
-      this._interactor.unbindEvents?.(this._container)
+      this._interactor.unbindEvents?.(this._container);
     } catch {
       // ignore — not all vtk.js versions expose unbindEvents
     }
-    const canvas = this._container.querySelector('canvas')
-    canvas?.remove()
+    const canvas = this._container.querySelector("canvas");
+    canvas?.remove();
   }
 
   private _setupLights(lights: LightConfig[]): void {
-    if (lights.length === 0) return
-    const vtk = getVtk()
-    this._renderer.removeAllLights()
-    this._renderer.setAutomaticLightCreation(false)
+    if (lights.length === 0) return;
+    const vtk = getVtk();
+    this._renderer.removeAllLights();
+    this._renderer.setAutomaticLightCreation(false);
     const typeMap: Record<string, string> = {
-      scene: 'setLightTypeToSceneLight',
-      camera: 'setLightTypeToCameraLight',
-      head: 'setLightTypeToHeadLight',
-    }
+      scene: "setLightTypeToSceneLight",
+      camera: "setLightTypeToCameraLight",
+      head: "setLightTypeToHeadLight",
+    };
     for (const cfg of lights) {
-      const light = vtk.Rendering.Core.vtkLight.newInstance()
-      const setter = typeMap[cfg.type] ?? 'setLightTypeToSceneLight'
-      const setterFn = light[setter]
-      if (typeof setterFn === 'function') {
-        (setterFn as () => void).call(light)
+      const light = vtk.Rendering.Core.vtkLight.newInstance();
+      const setter = typeMap[cfg.type] ?? "setLightTypeToSceneLight";
+      const setterFn = light[setter];
+      if (typeof setterFn === "function") {
+        (setterFn as () => void).call(light);
       }
-      light.setPosition(cfg.position[0], cfg.position[1], cfg.position[2])
-      light.setFocalPoint(cfg.focalPoint[0], cfg.focalPoint[1], cfg.focalPoint[2])
-      light.setColor(cfg.color[0], cfg.color[1], cfg.color[2])
-      light.setIntensity(cfg.intensity)
-      light.setPositional(cfg.positional)
-      light.setConeAngle(cfg.coneAngle)
-      light.setExponent(cfg.coneFalloff)
+      light.setPosition(cfg.position[0], cfg.position[1], cfg.position[2]);
+      light.setFocalPoint(cfg.focalPoint[0], cfg.focalPoint[1], cfg.focalPoint[2]);
+      light.setColor(cfg.color[0], cfg.color[1], cfg.color[2]);
+      light.setIntensity(cfg.intensity);
+      light.setPositional(cfg.positional);
+      light.setConeAngle(cfg.coneAngle);
+      light.setExponent(cfg.coneFalloff);
       light.setAttenuationValues(
         cfg.attenuationValues[0],
         cfg.attenuationValues[1],
         cfg.attenuationValues[2],
-      )
-      this._renderer.addLight(light)
+      );
+      this._renderer.addLight(light);
     }
   }
 
   private _createSource(cfg: SourceConfig): SourceResult | undefined {
-    const vtk = getVtk()
+    const vtk = getVtk();
     switch (cfg.type) {
-      case 'sphere':
-        return this._createSphereSource(cfg)
-      case 'cone':
+      case "sphere":
+        return this._createSphereSource(cfg);
+      case "cone":
         return {
           output: vtk.Filters.Sources.vtkConeSource.newInstance({
             height: cfg.height,
@@ -197,8 +193,8 @@ export class PyVistaRenderer {
             resolution: cfg.resolution,
           }),
           isFilter: true,
-        }
-      case 'cube':
+        };
+      case "cube":
         return {
           output: vtk.Filters.Sources.vtkCubeSource.newInstance({
             xLength: cfg.xLength,
@@ -206,8 +202,8 @@ export class PyVistaRenderer {
             zLength: cfg.zLength,
           }),
           isFilter: false,
-        }
-      case 'cylinder':
+        };
+      case "cylinder":
         return {
           output: vtk.Filters.Sources.vtkCylinderSource.newInstance({
             height: cfg.height,
@@ -215,17 +211,17 @@ export class PyVistaRenderer {
             resolution: cfg.resolution,
           }),
           isFilter: true,
-        }
-      case 'disk':
-        return this._createDiskSource(cfg)
-      case 'circle':
+        };
+      case "disk":
+        return this._createDiskSource(cfg);
+      case "circle":
         return this._createDiskSource({
-          type: 'disk',
+          type: "disk",
           innerRadius: 0,
           outerRadius: cfg.radius ?? DEFAULT_RADIUS,
           resolution: cfg.resolution ?? DEFAULT_RESOLUTION,
-        })
-      case 'arrow':
+        });
+      case "arrow":
         return {
           output: vtk.Filters.Sources.vtkArrowSource.newInstance({
             tipLength: cfg.tipLength,
@@ -233,54 +229,54 @@ export class PyVistaRenderer {
             shaftRadius: cfg.shaftRadius,
           }),
           isFilter: true,
-        }
-      case 'line':
+        };
+      case "line":
         return {
           output: vtk.Filters.Sources.vtkLineSource.newInstance({
             point1: cfg.point1,
             point2: cfg.point2,
           }),
           isFilter: true,
-        }
-      case 'plane': {
+        };
+      case "plane": {
         const source = vtk.Filters.Sources.vtkPlaneSource.newInstance({
           origin: cfg.origin,
-        })
+        });
         if (cfg.normal) {
-          source.setNormal?.(cfg.normal[0], cfg.normal[1], cfg.normal[2])
+          source.setNormal?.(cfg.normal[0], cfg.normal[1], cfg.normal[2]);
         }
-        return { output: source, isFilter: true }
+        return { output: source, isFilter: true };
       }
-      case 'mesh':
-        return this._createMeshSource(cfg)
-      case 'points':
-        return this._createPointsSource(cfg)
-      case 'plyReader':
-      case 'stlReader':
-      case 'objReader':
-      case 'vtkReader':
-        return this._createReaderSource(cfg)
+      case "mesh":
+        return this._createMeshSource(cfg);
+      case "points":
+        return this._createPointsSource(cfg);
+      case "plyReader":
+      case "stlReader":
+      case "objReader":
+      case "vtkReader":
+        return this._createReaderSource(cfg);
       default:
-        return undefined
+        return;
     }
   }
 
   private _createSphereSource(cfg: SourceConfig): SourceResult {
-    const vtk = getVtk()
+    const vtk = getVtk();
     const source = vtk.Filters.Sources.vtkSphereSource.newInstance({
       center: cfg.center,
       radius: cfg.radius,
       thetaResolution: cfg.thetaResolution,
       phiResolution: cfg.phiResolution,
-    })
-    const texMap = vtk.Filters.Texture.vtkTextureMapToSphere.newInstance()
-    texMap.setInputConnection(source.getOutputPort())
-    return { output: texMap, isFilter: true }
+    });
+    const texMap = vtk.Filters.Texture.vtkTextureMapToSphere.newInstance();
+    texMap.setInputConnection(source.getOutputPort());
+    return { output: texMap, isFilter: true };
   }
 
   private _createDiskSource(cfg: SourceConfig): SourceResult {
-    const vtk = getVtk()
-    const diskFactory = vtk.Filters.Sources.vtkDiskSource
+    const vtk = getVtk();
+    const diskFactory = vtk.Filters.Sources.vtkDiskSource;
     const source = diskFactory
       ? diskFactory.newInstance({
           innerRadius: cfg.innerRadius,
@@ -288,143 +284,150 @@ export class PyVistaRenderer {
           radialResolution: DISK_RADIAL_RESOLUTION,
           circumferentialResolution: cfg.resolution,
         })
-      : undefined
+      : undefined;
     return {
       output: source ?? vtk.Common.DataModel.vtkPolyData.newInstance(),
       isFilter: true,
-    }
+    };
   }
 
   private _createMeshSource(cfg: SourceConfig): SourceResult {
-    const vtk = getVtk()
-    const polydata = vtk.Common.DataModel.vtkPolyData.newInstance()
-    const pointsArray = Float32Array.from(cfg.points ?? [])
-    const vtkPts = vtk.Common.Core.vtkPoints.newInstance()
-    vtkPts.setData(pointsArray, XYZ_COMPONENTS)
-    polydata.setPoints(vtkPts)
+    const vtk = getVtk();
+    const polydata = vtk.Common.DataModel.vtkPolyData.newInstance();
+    const pointsArray = Float32Array.from(cfg.points ?? []);
+    const vtkPts = vtk.Common.Core.vtkPoints.newInstance();
+    vtkPts.setData(pointsArray, XYZ_COMPONENTS);
+    polydata.setPoints(vtkPts);
     if (cfg.polys) {
-      polydata.getPolys().setData(Uint32Array.from(cfg.polys))
+      polydata.getPolys().setData(Uint32Array.from(cfg.polys));
     }
-    return { output: polydata, isFilter: false }
+    return { output: polydata, isFilter: false };
   }
 
   private _createPointsSource(cfg: SourceConfig): SourceResult {
-    const vtk = getVtk()
-    const polydata = vtk.Common.DataModel.vtkPolyData.newInstance()
-    const pointsArray = Float32Array.from(cfg.points ?? [])
-    const vtkPts = vtk.Common.Core.vtkPoints.newInstance()
-    vtkPts.setData(pointsArray, XYZ_COMPONENTS)
-    polydata.setPoints(vtkPts)
-    return { output: polydata, isFilter: false }
+    const vtk = getVtk();
+    const polydata = vtk.Common.DataModel.vtkPolyData.newInstance();
+    const pointsArray = Float32Array.from(cfg.points ?? []);
+    const vtkPts = vtk.Common.Core.vtkPoints.newInstance();
+    vtkPts.setData(pointsArray, XYZ_COMPONENTS);
+    polydata.setPoints(vtkPts);
+    return { output: polydata, isFilter: false };
   }
 
   private _createReaderSource(cfg: SourceConfig): SourceResult {
-    const vtk = getVtk()
+    const vtk = getVtk();
     const readerMap: Record<string, { factory: AnyVtk; parseMethod: string }> = {
-      plyReader: { factory: vtk.IO.Geometry.vtkPLYReader, parseMethod: 'parseAsArrayBuffer' },
-      stlReader: { factory: vtk.IO.Geometry.vtkSTLReader, parseMethod: 'parseAsArrayBuffer' },
-      objReader: { factory: vtk.IO.Misc.vtkOBJReader, parseMethod: 'parseAsText' },
-      vtkReader: { factory: vtk.IO.Legacy.vtkPolyDataReader, parseMethod: 'parseAsText' },
-    }
-    const entry = readerMap[cfg.type]
-    if (!entry) throw new Error(`Unknown reader type: ${cfg.type}`)
-    const bytes = Uint8Array.from(atob(cfg.data ?? ''), (char) => char.codePointAt(0) ?? 0)
-    const reader = entry.factory.newInstance()
-    if (entry.parseMethod === 'parseAsText') {
-      reader.parseAsText(new TextDecoder().decode(bytes))
+      plyReader: { factory: vtk.IO.Geometry.vtkPLYReader, parseMethod: "parseAsArrayBuffer" },
+      stlReader: { factory: vtk.IO.Geometry.vtkSTLReader, parseMethod: "parseAsArrayBuffer" },
+      objReader: { factory: vtk.IO.Misc.vtkOBJReader, parseMethod: "parseAsText" },
+      vtkReader: { factory: vtk.IO.Legacy.vtkPolyDataReader, parseMethod: "parseAsText" },
+    };
+    const entry = readerMap[cfg.type];
+    if (!entry) throw new Error(`Unknown reader type: ${cfg.type}`);
+    const bytes = Uint8Array.from(atob(cfg.data ?? ""), (char) => char.codePointAt(0) ?? 0);
+    const reader = entry.factory.newInstance();
+    if (entry.parseMethod === "parseAsText") {
+      reader.parseAsText(new TextDecoder().decode(bytes));
     } else {
-      reader.parseAsArrayBuffer(new Uint8Array(bytes).buffer)
+      reader.parseAsArrayBuffer(new Uint8Array(bytes).buffer);
     }
-    return { output: reader, isFilter: true }
+    return { output: reader, isFilter: true };
   }
 
   private _injectPointData(polydata: AnyVtk, pointDataArrays: PointDataArray[] | undefined): void {
-    if (!pointDataArrays) return
-    const vtk = getVtk()
+    if (!pointDataArrays) return;
+    const vtk = getVtk();
     for (const array of pointDataArrays) {
       const dataArray = vtk.Common.Core.vtkDataArray.newInstance({
         numberOfComponents: array.numberOfComponents,
         values: Float32Array.from(array.values),
         name: array.name,
-      })
-      polydata.getPointData().addArray(dataArray)
+      });
+      polydata.getPointData().addArray(dataArray);
     }
   }
 
   private _injectTcoords(polydata: AnyVtk, tCoords: number[] | undefined): void {
-    if (!tCoords) return
-    const vtk = getVtk()
+    if (!tCoords) return;
+    const vtk = getVtk();
     const tcArray = vtk.Common.Core.vtkDataArray.newInstance({
       numberOfComponents: UV_COMPONENTS,
       values: Float32Array.from(tCoords),
-      name: 'TextureCoordinates',
-    })
-    polydata.getPointData().setTcoords(tcArray)
+      name: "TextureCoordinates",
+    });
+    polydata.getPointData().setTcoords(tcArray);
   }
 
-  private _setupNormals(sourceResult: SourceResult, normalsConfig: NormalsConfig | undefined): SourceResult {
-    if (!normalsConfig) return sourceResult
-    const vtk = getVtk()
-    const normals = vtk.Filters.Core.vtkPolyDataNormals.newInstance()
-    normals.setComputePointNormals?.(normalsConfig.computePointNormals)
-    normals.setComputeCellNormals?.(normalsConfig.computeCellNormals)
-    connectInput(normals, sourceResult)
-    return { output: normals, isFilter: true }
+  private _setupNormals(
+    sourceResult: SourceResult,
+    normalsConfig: NormalsConfig | undefined,
+  ): SourceResult {
+    if (!normalsConfig) return sourceResult;
+    const vtk = getVtk();
+    const normals = vtk.Filters.Core.vtkPolyDataNormals.newInstance();
+    normals.setComputePointNormals?.(normalsConfig.computePointNormals);
+    normals.setComputeCellNormals?.(normalsConfig.computeCellNormals);
+    connectInput(normals, sourceResult);
+    return { output: normals, isFilter: true };
   }
 
   private _applyFilters(sourceResult: SourceResult, filters: FilterConfig[]): SourceResult {
-    let current = sourceResult
+    let current = sourceResult;
     for (const f of filters) {
       switch (f.type) {
-        case 'shrink':
-          if (f.shrinkFactor !== undefined) current = this._applyShrinkFilter(current, f.shrinkFactor)
-          break
-        case 'tube':
+        case "shrink":
+          if (f.shrinkFactor !== undefined)
+            current = this._applyShrinkFilter(current, f.shrinkFactor);
+          break;
+        case "tube":
           if (f.radius !== undefined && f.numberOfSides !== undefined)
-            current = this._applyTubeFilter(current, f.radius, f.numberOfSides)
-          break
-        case 'clip':
+            current = this._applyTubeFilter(current, f.radius, f.numberOfSides);
+          break;
+        case "clip":
           if (f.normal && f.origin && f.invert !== undefined)
-            current = this._applyClipFilter(current, f.normal, f.origin, f.invert)
-          break
-        case 'contour':
+            current = this._applyClipFilter(current, f.normal, f.origin, f.invert);
+          break;
+        case "contour":
           if (f.values && f.scalarName && f.scalarData)
-            current = this._applyContourFilter(current, f.values, f.scalarName, f.scalarData)
-          break
-        case 'fillHoles':
-          if (f.holeSize !== undefined) current = this._applyFillHolesFilter(current, f.holeSize)
-          break
+            current = this._applyContourFilter(current, f.values, f.scalarName, f.scalarData);
+          break;
+        case "fillHoles":
+          if (f.holeSize !== undefined) current = this._applyFillHolesFilter(current, f.holeSize);
+          break;
+
+        default:
+          break;
       }
     }
-    return current
+    return current;
   }
 
   private _applyPbr(actor: AnyVtk, pbr: PbrConfig | undefined): void {
-    if (!pbr) return
-    const m = pbr.metallic
-    const r = pbr.roughness
-    actor.getProperty().setInterpolationToPhong()
-    actor.getProperty().setMetallic(m)
-    actor.getProperty().setRoughness(r)
-    actor.getProperty().setAmbient(PBR_AMBIENT)
-    actor.getProperty().setSpecular(PBR_SPECULAR_METALLIC_WEIGHT * m + PBR_SPECULAR_BASE)
-    actor.getProperty().setSpecularPower(Math.max(1, PBR_SPECULAR_POWER_SCALE * (1 - r)))
-    actor.getProperty().setDiffuse(PBR_DIFFUSE_BASE + PBR_DIFFUSE_METALLIC_WEIGHT * (1 - m))
+    if (!pbr) return;
+    const m = pbr.metallic;
+    const r = pbr.roughness;
+    actor.getProperty().setInterpolationToPhong();
+    actor.getProperty().setMetallic(m);
+    actor.getProperty().setRoughness(r);
+    actor.getProperty().setAmbient(PBR_AMBIENT);
+    actor.getProperty().setSpecular(PBR_SPECULAR_METALLIC_WEIGHT * m + PBR_SPECULAR_BASE);
+    actor.getProperty().setSpecularPower(Math.max(1, PBR_SPECULAR_POWER_SCALE * (1 - r)));
+    actor.getProperty().setDiffuse(PBR_DIFFUSE_BASE + PBR_DIFFUSE_METALLIC_WEIGHT * (1 - m));
   }
 
   private _applyTexture(actor: AnyVtk, textureCfg: TextureConfig | undefined): void {
-    if (!textureCfg) return
-    const vtk = getVtk()
-    const texture = vtk.Rendering.Core.vtkTexture.newInstance()
-    texture.setInterpolate(true)
-    actor.addTexture(texture)
-    const img = new Image()
-    img.crossOrigin = 'anonymous'
-    img.addEventListener('load', () => {
-      texture.setImage(img)
-      this._renderWindow.render()
-    })
-    img.src = textureCfg.url
+    if (!textureCfg) return;
+    const vtk = getVtk();
+    const texture = vtk.Rendering.Core.vtkTexture.newInstance();
+    texture.setInterpolate(true);
+    actor.addTexture(texture);
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    img.addEventListener("load", () => {
+      texture.setImage(img);
+      this._renderWindow.render();
+    });
+    img.src = textureCfg.url;
   }
 
   private _applyActorStyle(actor: AnyVtk, cfg: ActorConfig): void {
@@ -432,200 +435,204 @@ export class PyVistaRenderer {
       surface: VTK_REPRESENTATION_SURFACE,
       wireframe: VTK_REPRESENTATION_WIREFRAME,
       points: VTK_REPRESENTATION_POINTS,
-    }
-    const rep = styleMap[cfg.style]
-    if (rep !== undefined) actor.getProperty().setRepresentation(rep)
-    if (cfg.shading === 'gouraud') {
-      actor.getProperty().setInterpolationToGouraud()
-    } else if (cfg.shading === 'flat') {
-      actor.getProperty().setInterpolationToFlat()
+    };
+    const rep = styleMap[cfg.style];
+    if (rep !== undefined) actor.getProperty().setRepresentation(rep);
+    if (cfg.shading === "gouraud") {
+      actor.getProperty().setInterpolationToGouraud();
+    } else if (cfg.shading === "flat") {
+      actor.getProperty().setInterpolationToFlat();
     }
     if (cfg.edges) {
-      actor.getProperty().setEdgeVisibility(true)
-      actor.getProperty().setEdgeColor(
-        cfg.edges.color[0],
-        cfg.edges.color[1],
-        cfg.edges.color[2],
-      )
+      actor.getProperty().setEdgeVisibility(true);
+      actor.getProperty().setEdgeColor(cfg.edges.color[0], cfg.edges.color[1], cfg.edges.color[2]);
     }
   }
 
   private _applyPointStyle(actor: AnyVtk, mapper: AnyVtk, cfg: ActorConfig): void {
-    if (cfg.actorType !== 'points') return
+    if (cfg.actorType !== "points") return;
     if (cfg.renderPointsAsSpheres && mapper.setRadius) {
-      mapper.setRadius((cfg.pointSize ?? DEFAULT_POINT_SIZE) * POINT_SPHERE_RADIUS_SCALE)
+      mapper.setRadius((cfg.pointSize ?? DEFAULT_POINT_SIZE) * POINT_SPHERE_RADIUS_SCALE);
     } else {
-      actor.getProperty().setPointSize(cfg.pointSize ?? DEFAULT_POINT_SIZE)
-      actor.getProperty().setRepresentationToPoints()
+      actor.getProperty().setPointSize(cfg.pointSize ?? DEFAULT_POINT_SIZE);
+      actor.getProperty().setRepresentationToPoints();
     }
   }
 
   private _createMapper(mapperInput: SourceResult, cfg: ActorConfig): AnyVtk {
-    const vtk = getVtk()
+    const vtk = getVtk();
     const mapperClass =
-      cfg.actorType === 'points' && cfg.renderPointsAsSpheres
+      cfg.actorType === "points" && cfg.renderPointsAsSpheres
         ? vtk.Rendering.Core.vtkSphereMapper
-        : vtk.Rendering.Core.vtkMapper
-    const mapper = mapperClass.newInstance()
+        : vtk.Rendering.Core.vtkMapper;
+    const mapper = mapperClass.newInstance();
     if (mapperInput.isFilter) {
-      mapper.setInputConnection(mapperInput.output.getOutputPort())
+      mapper.setInputConnection(mapperInput.output.getOutputPort());
     } else {
-      mapper.setInputData(mapperInput.output)
+      mapper.setInputData(mapperInput.output);
     }
-    return mapper
+    return mapper;
   }
 
   private _setupActor(cfg: ActorConfig, _index: number): void {
-    const vtk = getVtk()
-    const sourceResult = this._createSource(cfg.source)
-    if (!sourceResult?.output) return
+    const vtk = getVtk();
+    const sourceResult = this._createSource(cfg.source);
+    if (!sourceResult?.output) return;
 
     if (cfg.source.pointData ?? cfg.source.tCoords) {
-      const pd = getPolyData(sourceResult)
-      this._injectPointData(pd, cfg.source.pointData)
-      this._injectTcoords(pd, cfg.source.tCoords)
+      const pd = getPolyData(sourceResult);
+      this._injectPointData(pd, cfg.source.pointData);
+      this._injectTcoords(pd, cfg.source.tCoords);
     }
 
-    let currentResult = sourceResult
+    let currentResult = sourceResult;
     if (cfg.source.filters && cfg.source.filters.length > 0) {
-      currentResult = this._applyFilters(sourceResult, cfg.source.filters)
+      currentResult = this._applyFilters(sourceResult, cfg.source.filters);
     }
 
-    const mapperInput = this._setupNormals(currentResult, cfg.normals)
-    const mapper = this._createMapper(mapperInput, cfg)
+    const mapperInput = this._setupNormals(currentResult, cfg.normals);
+    const mapper = this._createMapper(mapperInput, cfg);
 
-    const actor = vtk.Rendering.Core.vtkActor.newInstance()
-    actor.setMapper(mapper)
-    actor.getProperty().setColor(cfg.color[0], cfg.color[1], cfg.color[2])
-    actor.getProperty().setOpacity(cfg.opacity)
+    const actor = vtk.Rendering.Core.vtkActor.newInstance();
+    actor.setMapper(mapper);
+    actor.getProperty().setColor(cfg.color[0], cfg.color[1], cfg.color[2]);
+    actor.getProperty().setOpacity(cfg.opacity);
 
-    this._applyActorStyle(actor, cfg)
-    this._applyPbr(actor, cfg.pbr)
-    this._applyPointStyle(actor, mapper, cfg)
-    this._applyTexture(actor, cfg.texture)
+    this._applyActorStyle(actor, cfg);
+    this._applyPbr(actor, cfg.pbr);
+    this._applyPointStyle(actor, mapper, cfg);
+    this._applyTexture(actor, cfg.texture);
 
-    this._renderer.addActor(actor)
+    this._renderer.addActor(actor);
   }
 
   private _setupCamera(camConfig: CameraConfig): void {
-    const cam = this._renderer.getActiveCamera()
+    const cam = this._renderer.getActiveCamera();
     if (camConfig.position) {
-      cam.setPosition(camConfig.position[0], camConfig.position[1], camConfig.position[2])
+      cam.setPosition(camConfig.position[0], camConfig.position[1], camConfig.position[2]);
     }
     if (camConfig.focalPoint) {
-      cam.setFocalPoint(camConfig.focalPoint[0], camConfig.focalPoint[1], camConfig.focalPoint[2])
+      cam.setFocalPoint(camConfig.focalPoint[0], camConfig.focalPoint[1], camConfig.focalPoint[2]);
     }
     if (camConfig.viewUp) {
-      cam.setViewUp(camConfig.viewUp[0], camConfig.viewUp[1], camConfig.viewUp[2])
+      cam.setViewUp(camConfig.viewUp[0], camConfig.viewUp[1], camConfig.viewUp[2]);
     }
     if (camConfig.viewAngle !== undefined) {
-      cam.setViewAngle(camConfig.viewAngle)
+      cam.setViewAngle(camConfig.viewAngle);
     }
     if (camConfig.clippingRange) {
-      cam.setClippingRange(camConfig.clippingRange[0], camConfig.clippingRange[1])
+      cam.setClippingRange(camConfig.clippingRange[0], camConfig.clippingRange[1]);
     }
     if (camConfig.parallelProjection) {
-      cam.setParallelProjection(true)
+      cam.setParallelProjection(true);
     }
     if (camConfig.viewVector && camConfig.viewUp) {
-      cam.setPosition(camConfig.viewVector[0], camConfig.viewVector[1], camConfig.viewVector[2])
-      cam.setViewUp(camConfig.viewUp[0], camConfig.viewUp[1], camConfig.viewUp[2])
-      cam.setFocalPoint(0, 0, 0)
-      this._renderer.resetCamera()
-      this._renderer.resetCameraClippingRange()
+      cam.setPosition(camConfig.viewVector[0], camConfig.viewVector[1], camConfig.viewVector[2]);
+      cam.setViewUp(camConfig.viewUp[0], camConfig.viewUp[1], camConfig.viewUp[2]);
+      cam.setFocalPoint(0, 0, 0);
+      this._renderer.resetCamera();
+      this._renderer.resetCameraClippingRange();
     }
   }
 
   private _setupAxes(): void {
-    const vtk = getVtk()
-    const axes = vtk.Rendering.Core.vtkAxesActor.newInstance()
+    const vtk = getVtk();
+    const axes = vtk.Rendering.Core.vtkAxesActor.newInstance();
     const orientationWidget = vtk.Interaction.Widgets.vtkOrientationMarkerWidget.newInstance({
       actor: axes,
       interactor: this._interactor,
-    })
-    orientationWidget.setEnabled(true)
+    });
+    orientationWidget.setEnabled(true);
     orientationWidget.setViewportCorner(
       vtk.Interaction.Widgets.vtkOrientationMarkerWidget.Corners.BOTTOM_LEFT,
-    )
-    orientationWidget.setViewportSize(AXES_VIEWPORT_SIZE)
-    orientationWidget.setMinPixelSize(AXES_MIN_PIXEL_SIZE)
-    orientationWidget.setMaxPixelSize(AXES_MAX_PIXEL_SIZE)
+    );
+    orientationWidget.setViewportSize(AXES_VIEWPORT_SIZE);
+    orientationWidget.setMinPixelSize(AXES_MIN_PIXEL_SIZE);
+    orientationWidget.setMaxPixelSize(AXES_MAX_PIXEL_SIZE);
   }
 
   private _setupTextActor(cfg: TextActorConfig): void {
-    const div = document.createElement('div')
-    div.textContent = cfg.text
-    div.style.position = 'absolute'
-    div.style.left = `${String(cfg.position[0] * PERCENT)}%`
-    div.style.bottom = `${String(cfg.position[1] * PERCENT)}%`
-    const r = Math.round(cfg.color[0] * COLOR_BYTE_SCALE)
-    const g = Math.round(cfg.color[1] * COLOR_BYTE_SCALE)
-    const b = Math.round(cfg.color[2] * COLOR_BYTE_SCALE)
-    div.style.color = `rgba(${String(r)},${String(g)},${String(b)},${String(cfg.opacity)})`
-    div.style.fontSize = `${String(cfg.fontSize)}px`
-    div.style.fontWeight = cfg.bold ? 'bold' : 'normal'
-    div.style.fontStyle = cfg.italic ? 'italic' : 'normal'
-    div.style.pointerEvents = 'none'
-    div.style.zIndex = '10'
-    div.style.whiteSpace = 'pre'
-    div.style.textShadow = '1px 1px 2px rgba(0,0,0,0.8), -1px -1px 2px rgba(0,0,0,0.8)'
-    this._container.append(div)
+    const div = document.createElement("div");
+    div.textContent = cfg.text;
+    div.style.position = "absolute";
+    div.style.left = `${String(cfg.position[0] * PERCENT)}%`;
+    div.style.bottom = `${String(cfg.position[1] * PERCENT)}%`;
+    const r = Math.round(cfg.color[0] * COLOR_BYTE_SCALE);
+    const g = Math.round(cfg.color[1] * COLOR_BYTE_SCALE);
+    const b = Math.round(cfg.color[2] * COLOR_BYTE_SCALE);
+    div.style.color = `rgba(${String(r)},${String(g)},${String(b)},${String(cfg.opacity)})`;
+    div.style.fontSize = `${String(cfg.fontSize)}px`;
+    div.style.fontWeight = cfg.bold ? "bold" : "normal";
+    div.style.fontStyle = cfg.italic ? "italic" : "normal";
+    div.style.pointerEvents = "none";
+    div.style.zIndex = "10";
+    div.style.whiteSpace = "pre";
+    div.style.textShadow = "1px 1px 2px rgba(0,0,0,0.8), -1px -1px 2px rgba(0,0,0,0.8)";
+    this._container.append(div);
   }
 
   // --- Filter implementations ---
 
   private _applyShrinkFilter(sourceResult: SourceResult, shrinkFactor: number): SourceResult {
-    const vtk = getVtk()
-    const inputPd = getPolyData(sourceResult)
-    const inPoints = inputPd.getPoints().getData()
-    const polys = inputPd.getPolys().getData()
-    if (polys.length === 0) return sourceResult
+    const vtk = getVtk();
+    const inputPd = getPolyData(sourceResult);
+    const inPoints = inputPd.getPoints().getData();
+    const polys = inputPd.getPolys().getData();
+    if (polys.length === 0) return sourceResult;
 
-    const resultPoints: number[] = []
-    const resultPolys: number[] = []
-    let offset = 0
-    let index = 0
+    const resultPoints: number[] = [];
+    const resultPolys: number[] = [];
+    let offset = 0;
+    let index = 0;
     while (index < polys.length) {
-      const nVerts = at(polys, index)
-      index++
-      let cx = 0, cy = 0, cz = 0
-      const indices: number[] = []
+      const nVerts = at(polys, index);
+      index++;
+      let cx = 0,
+        cy = 0,
+        cz = 0;
+      const indices: number[] = [];
       for (let i = 0; i < nVerts; i++) {
-        const vi = at(polys, index + i)
-        indices.push(vi)
-        cx += at(inPoints, vi * XYZ_COMPONENTS)
-        cy += at(inPoints, vi * XYZ_COMPONENTS + 1)
-        cz += at(inPoints, vi * XYZ_COMPONENTS + 2)
+        const vi = at(polys, index + i);
+        indices.push(vi);
+        cx += at(inPoints, vi * XYZ_COMPONENTS);
+        cy += at(inPoints, vi * XYZ_COMPONENTS + 1);
+        cz += at(inPoints, vi * XYZ_COMPONENTS + 2);
       }
-      cx /= nVerts; cy /= nVerts; cz /= nVerts
-      resultPolys.push(nVerts)
+      cx /= nVerts;
+      cy /= nVerts;
+      cz /= nVerts;
+      resultPolys.push(nVerts);
       for (let k = 0; k < nVerts; k++) {
-        const pi = indices[k] ?? 0
-        const px = at(inPoints, pi * XYZ_COMPONENTS)
-        const py = at(inPoints, pi * XYZ_COMPONENTS + 1)
-        const pz = at(inPoints, pi * XYZ_COMPONENTS + 2)
+        const pi = indices[k] ?? 0;
+        const px = at(inPoints, pi * XYZ_COMPONENTS);
+        const py = at(inPoints, pi * XYZ_COMPONENTS + 1);
+        const pz = at(inPoints, pi * XYZ_COMPONENTS + 2);
         resultPoints.push(
           cx + (px - cx) * shrinkFactor,
           cy + (py - cy) * shrinkFactor,
           cz + (pz - cz) * shrinkFactor,
-        )
-        resultPolys.push(offset + k)
+        );
+        resultPolys.push(offset + k);
       }
-      offset += nVerts
-      index += nVerts
+      offset += nVerts;
+      index += nVerts;
     }
 
-    const outputPd = vtk.Common.DataModel.vtkPolyData.newInstance()
-    outputPd.getPoints().setData(new Float32Array(resultPoints), XYZ_COMPONENTS)
-    outputPd.getPolys().setData(new Uint32Array(resultPolys))
-    return { output: outputPd, isFilter: false }
+    const outputPd = vtk.Common.DataModel.vtkPolyData.newInstance();
+    outputPd.getPoints().setData(new Float32Array(resultPoints), XYZ_COMPONENTS);
+    outputPd.getPolys().setData(new Uint32Array(resultPolys));
+    return { output: outputPd, isFilter: false };
   }
 
-  private _applyTubeFilter(sourceResult: SourceResult, radius: number, numberOfSides: number): SourceResult {
-    const vtk = getVtk()
-    const tubeFilter = vtk.Filters.General.vtkTubeFilter.newInstance({ radius, numberOfSides })
-    connectInput(tubeFilter, sourceResult)
-    return { output: tubeFilter, isFilter: true }
+  private _applyTubeFilter(
+    sourceResult: SourceResult,
+    radius: number,
+    numberOfSides: number,
+  ): SourceResult {
+    const vtk = getVtk();
+    const tubeFilter = vtk.Filters.General.vtkTubeFilter.newInstance({ radius, numberOfSides });
+    connectInput(tubeFilter, sourceResult);
+    return { output: tubeFilter, isFilter: true };
   }
 
   private _applyClipFilter(
@@ -634,18 +641,18 @@ export class PyVistaRenderer {
     origin: [number, number, number],
     invert: boolean,
   ): SourceResult {
-    const vtk = getVtk()
-    const plane = vtk.Common.DataModel.vtkPlane.newInstance()
-    plane.setOrigin(origin[0], origin[1], origin[2])
-    plane.setNormal(normal[0], normal[1], normal[2])
-    const clipFactory = vtk.Filters.General.vtkClipClosedSurface
+    const vtk = getVtk();
+    const plane = vtk.Common.DataModel.vtkPlane.newInstance();
+    plane.setOrigin(origin[0], origin[1], origin[2]);
+    plane.setNormal(normal[0], normal[1], normal[2]);
+    const clipFactory = vtk.Filters.General.vtkClipClosedSurface;
     if (clipFactory) {
-      const clipper = clipFactory.newInstance()
-      clipper.setClippingPlanes?.([plane])
-      connectInput(clipper, sourceResult)
-      return { output: clipper, isFilter: true }
+      const clipper = clipFactory.newInstance();
+      clipper.setClippingPlanes?.([plane]);
+      connectInput(clipper, sourceResult);
+      return { output: clipper, isFilter: true };
     }
-    return this._applyClipManual(sourceResult, normal, origin, invert)
+    return this._applyClipManual(sourceResult, normal, origin, invert);
   }
 
   private _applyClipManual(
@@ -654,54 +661,59 @@ export class PyVistaRenderer {
     origin: [number, number, number],
     invert: boolean,
   ): SourceResult {
-    const vtk = getVtk()
-    const inputPd = getPolyData(sourceResult)
-    const inPoints = inputPd.getPoints().getData()
-    const polys = inputPd.getPolys().getData()
-    if (polys.length === 0) return sourceResult
+    const vtk = getVtk();
+    const inputPd = getPolyData(sourceResult);
+    const inPoints = inputPd.getPoints().getData();
+    const polys = inputPd.getPolys().getData();
+    if (polys.length === 0) return sourceResult;
 
-    const resultPoints: number[] = []
-    const resultPolys: number[] = []
-    const pointMap = new Map<number, number>()
-    let nextIndex = 0
-    let index = 0
+    const resultPoints: number[] = [];
+    const resultPolys: number[] = [];
+    const pointMap = new Map<number, number>();
+    let nextIndex = 0;
+    let index = 0;
     while (index < polys.length) {
-      const nVerts = at(polys, index)
-      index++
-      const cellIndices: number[] = []
-      for (let i = 0; i < nVerts; i++) cellIndices.push(at(polys, index + i))
+      const nVerts = at(polys, index);
+      index++;
+      const cellIndices: number[] = [];
+      for (let i = 0; i < nVerts; i++) cellIndices.push(at(polys, index + i));
 
-      let cx = 0, cy = 0, cz = 0
+      let cx = 0,
+        cy = 0,
+        cz = 0;
       for (const vi of cellIndices) {
-        cx += at(inPoints, vi * XYZ_COMPONENTS)
-        cy += at(inPoints, vi * XYZ_COMPONENTS + 1)
-        cz += at(inPoints, vi * XYZ_COMPONENTS + 2)
+        cx += at(inPoints, vi * XYZ_COMPONENTS);
+        cy += at(inPoints, vi * XYZ_COMPONENTS + 1);
+        cz += at(inPoints, vi * XYZ_COMPONENTS + 2);
       }
-      cx /= nVerts; cy /= nVerts; cz /= nVerts
-      const dot = (cx - origin[0]) * normal[0] + (cy - origin[1]) * normal[1] + (cz - origin[2]) * normal[2]
-      const keep = invert ? dot >= 0 : dot <= 0
+      cx /= nVerts;
+      cy /= nVerts;
+      cz /= nVerts;
+      const dot =
+        (cx - origin[0]) * normal[0] + (cy - origin[1]) * normal[1] + (cz - origin[2]) * normal[2];
+      const keep = invert ? dot >= 0 : dot <= 0;
 
       if (keep) {
-        resultPolys.push(cellIndices.length)
+        resultPolys.push(cellIndices.length);
         for (const pi of cellIndices) {
           if (!pointMap.has(pi)) {
-            pointMap.set(pi, nextIndex++)
+            pointMap.set(pi, nextIndex++);
             resultPoints.push(
               at(inPoints, pi * XYZ_COMPONENTS),
               at(inPoints, pi * XYZ_COMPONENTS + 1),
               at(inPoints, pi * XYZ_COMPONENTS + 2),
-            )
+            );
           }
-          resultPolys.push(pointMap.get(pi) ?? 0)
+          resultPolys.push(pointMap.get(pi) ?? 0);
         }
       }
-      index += nVerts
+      index += nVerts;
     }
 
-    const outputPd = vtk.Common.DataModel.vtkPolyData.newInstance()
-    outputPd.getPoints().setData(new Float32Array(resultPoints), XYZ_COMPONENTS)
-    outputPd.getPolys().setData(new Uint32Array(resultPolys))
-    return { output: outputPd, isFilter: false }
+    const outputPd = vtk.Common.DataModel.vtkPolyData.newInstance();
+    outputPd.getPoints().setData(new Float32Array(resultPoints), XYZ_COMPONENTS);
+    outputPd.getPolys().setData(new Uint32Array(resultPolys));
+    return { output: outputPd, isFilter: false };
   }
 
   private _applyContourFilter(
@@ -710,135 +722,162 @@ export class PyVistaRenderer {
     scalarName: string,
     scalarData: number[],
   ): SourceResult {
-    const vtk = getVtk()
-    const inputPd = getPolyData(sourceResult)
+    const vtk = getVtk();
+    const inputPd = getPolyData(sourceResult);
     const scalars = vtk.Common.Core.vtkDataArray.newInstance({
       numberOfComponents: 1,
       values: Float32Array.from(scalarData),
       name: scalarName,
-    })
-    inputPd.getPointData().addArray(scalars)
-    inputPd.getPointData().setActiveScalars(scalarName)
+    });
+    inputPd.getPointData().addArray(scalars);
+    inputPd.getPointData().setActiveScalars(scalarName);
 
-    const inPoints = inputPd.getPoints().getData()
-    const polys = inputPd.getPolys().getData()
-    const scalarValues = scalars.getData()
-    if (polys.length === 0) return { output: inputPd, isFilter: false }
+    const inPoints = inputPd.getPoints().getData();
+    const polys = inputPd.getPolys().getData();
+    const scalarValues = scalars.getData();
+    if (polys.length === 0) return { output: inputPd, isFilter: false };
 
-    const outPoints: number[] = []
-    const outPolys: number[] = []
-    let pointIndex = 0
-    let index = 0
+    const outPoints: number[] = [];
+    const outPolys: number[] = [];
+    let pointIndex = 0;
+    let index = 0;
     while (index < polys.length) {
-      const nVerts = at(polys, index)
-      index++
+      const nVerts = at(polys, index);
+      index++;
       if (nVerts === TRIANGLE_VERTS) {
-        const i0 = at(polys, index), i1 = at(polys, index + 1), i2 = at(polys, index + 2)
-        const s0 = at(scalarValues, i0), s1 = at(scalarValues, i1), s2 = at(scalarValues, i2)
-        const edges: [number, number, number, number][] = [[i0, i1, s0, s1], [i1, i2, s1, s2], [i2, i0, s2, s0]]
+        const i0 = at(polys, index),
+          i1 = at(polys, index + 1),
+          i2 = at(polys, index + 2);
+        const s0 = at(scalarValues, i0),
+          s1 = at(scalarValues, i1),
+          s2 = at(scalarValues, i2);
+        const edges: [number, number, number, number][] = [
+          [i0, i1, s0, s1],
+          [i1, i2, s1, s2],
+          [i2, i0, s2, s0],
+        ];
         for (const value of values) {
-          const edgePoints: number[] = []
+          const edgePoints: number[] = [];
           for (const [ai, bi, sa, sb] of edges) {
             if ((sa <= value && value < sb) || (sb <= value && value < sa)) {
-              const t = (value - sa) / (sb - sa)
+              const t = (value - sa) / (sb - sa);
               edgePoints.push(
-                at(inPoints, ai * XYZ_COMPONENTS) + t * (at(inPoints, bi * XYZ_COMPONENTS) - at(inPoints, ai * XYZ_COMPONENTS)),
-                at(inPoints, ai * XYZ_COMPONENTS + 1) + t * (at(inPoints, bi * XYZ_COMPONENTS + 1) - at(inPoints, ai * XYZ_COMPONENTS + 1)),
-                at(inPoints, ai * XYZ_COMPONENTS + 2) + t * (at(inPoints, bi * XYZ_COMPONENTS + 2) - at(inPoints, ai * XYZ_COMPONENTS + 2)),
-              )
+                at(inPoints, ai * XYZ_COMPONENTS) +
+                  t * (at(inPoints, bi * XYZ_COMPONENTS) - at(inPoints, ai * XYZ_COMPONENTS)),
+                at(inPoints, ai * XYZ_COMPONENTS + 1) +
+                  t *
+                    (at(inPoints, bi * XYZ_COMPONENTS + 1) - at(inPoints, ai * XYZ_COMPONENTS + 1)),
+                at(inPoints, ai * XYZ_COMPONENTS + 2) +
+                  t *
+                    (at(inPoints, bi * XYZ_COMPONENTS + 2) - at(inPoints, ai * XYZ_COMPONENTS + 2)),
+              );
             }
           }
           if (edgePoints.length === TWO_POINTS_XYZ) {
-            outPoints.push(...edgePoints)
-            outPolys.push(2, pointIndex, pointIndex + 1)
-            pointIndex += 2
+            outPoints.push(...edgePoints);
+            outPolys.push(2, pointIndex, pointIndex + 1);
+            pointIndex += 2;
           }
         }
       }
-      index += nVerts
+      index += nVerts;
     }
 
-    const outputPd = vtk.Common.DataModel.vtkPolyData.newInstance()
+    const outputPd = vtk.Common.DataModel.vtkPolyData.newInstance();
     if (outPoints.length > 0) {
-      outputPd.getPoints().setData(new Float32Array(outPoints), XYZ_COMPONENTS)
-      outputPd.getLines().setData(new Uint32Array(outPolys))
+      outputPd.getPoints().setData(new Float32Array(outPoints), XYZ_COMPONENTS);
+      outputPd.getLines().setData(new Uint32Array(outPolys));
     }
-    return { output: outputPd, isFilter: false }
+    return { output: outputPd, isFilter: false };
   }
 
   private _applyFillHolesFilter(sourceResult: SourceResult, holeSize: number): SourceResult {
-    const vtk = getVtk()
-    const inputPd = getPolyData(sourceResult)
-    const inPoints = inputPd.getPoints().getData()
-    const polys = inputPd.getPolys().getData()
-    if (polys.length === 0) return sourceResult
+    const vtk = getVtk();
+    const inputPd = getPolyData(sourceResult);
+    const inPoints = inputPd.getPoints().getData();
+    const polys = inputPd.getPolys().getData();
+    if (polys.length === 0) return sourceResult;
 
-    const edgeCount = new Map<string, number>()
-    let index = 0
+    const edgeCount = new Map<string, number>();
+    let index = 0;
     while (index < polys.length) {
-      const nVerts = at(polys, index)
-      index++
+      const nVerts = at(polys, index);
+      index++;
       for (let k = 0; k < nVerts; k++) {
-        const a = at(polys, index + k)
-        const b = at(polys, index + ((k + 1) % nVerts))
-        const key = `${String(Math.min(a, b))}_${String(Math.max(a, b))}`
-        edgeCount.set(key, (edgeCount.get(key) ?? 0) + 1)
+        const a = at(polys, index + k);
+        const b = at(polys, index + ((k + 1) % nVerts));
+        const key = `${String(Math.min(a, b))}_${String(Math.max(a, b))}`;
+        edgeCount.set(key, (edgeCount.get(key) ?? 0) + 1);
       }
-      index += nVerts
+      index += nVerts;
     }
 
-    const boundaryAdj = new Map<number, number[]>()
+    const boundaryAdj = new Map<number, number[]>();
     for (const [key, count] of edgeCount) {
-      if (count !== 1) continue
-      const parts = key.split('_')
-      const a = Number(parts[0]), b = Number(parts[1])
-      ;(boundaryAdj.get(a) ?? boundaryAdj.set(a, []).get(a)!).push(b)
-      ;(boundaryAdj.get(b) ?? boundaryAdj.set(b, []).get(b)!).push(a)
+      if (count !== 1) continue;
+      const parts = key.split("_");
+      const a = Number(parts[0]),
+        b = Number(parts[1]);
+      // biome-ignore lint/style/noNonNullAssertion: Map.get after Map.set always returns the value
+      (boundaryAdj.get(a) ?? boundaryAdj.set(a, []).get(a)!).push(b);
+      // biome-ignore lint/style/noNonNullAssertion: Map.get after Map.set always returns the value
+      (boundaryAdj.get(b) ?? boundaryAdj.set(b, []).get(b)!).push(a);
     }
-    if (boundaryAdj.size === 0) return sourceResult
+    if (boundaryAdj.size === 0) return sourceResult;
 
-    const visited = new Set<number>()
-    const loops: number[][] = []
+    const visited = new Set<number>();
+    const loops: number[][] = [];
     for (const startNode of boundaryAdj.keys()) {
-      if (visited.has(startNode)) continue
-      const loop: number[] = []
-      let current = startNode, previous = -1, stuck = false
+      if (visited.has(startNode)) continue;
+      const loop: number[] = [];
+      let current = startNode,
+        previous = -1,
+        stuck = false;
       while (!stuck) {
-        visited.add(current)
-        loop.push(current)
-        const neighbors = boundaryAdj.get(current) ?? []
-        let next = -1
+        visited.add(current);
+        loop.push(current);
+        const neighbors = boundaryAdj.get(current) ?? [];
+        let next = -1;
         for (const n of neighbors) {
-          if (n !== previous && !visited.has(n)) { next = n; break }
+          if (n !== previous && !visited.has(n)) {
+            next = n;
+            break;
+          }
         }
-        if (next === -1) { stuck = true } else { previous = current; current = next }
+        if (next === -1) {
+          stuck = true;
+        } else {
+          previous = current;
+          current = next;
+        }
       }
-      if (loop.length > 2) loops.push(loop)
+      if (loop.length > 2) loops.push(loop);
     }
 
-    const newPolys: number[] = []
+    const newPolys: number[] = [];
     for (const loop of loops) {
-      let perimeter = 0
+      let perimeter = 0;
       for (let k = 0; k < loop.length; k++) {
-        const a = loop[k] ?? 0, b = loop[(k + 1) % loop.length] ?? 0
-        const dx = at(inPoints, b * XYZ_COMPONENTS) - at(inPoints, a * XYZ_COMPONENTS)
-        const dy = at(inPoints, b * XYZ_COMPONENTS + 1) - at(inPoints, a * XYZ_COMPONENTS + 1)
-        const dz = at(inPoints, b * XYZ_COMPONENTS + 2) - at(inPoints, a * XYZ_COMPONENTS + 2)
-        perimeter += Math.hypot(dx, dy, dz)
+        const a = loop[k] ?? 0,
+          b = loop[(k + 1) % loop.length] ?? 0;
+        const dx = at(inPoints, b * XYZ_COMPONENTS) - at(inPoints, a * XYZ_COMPONENTS);
+        const dy = at(inPoints, b * XYZ_COMPONENTS + 1) - at(inPoints, a * XYZ_COMPONENTS + 1);
+        const dz = at(inPoints, b * XYZ_COMPONENTS + 2) - at(inPoints, a * XYZ_COMPONENTS + 2);
+        perimeter += Math.hypot(dx, dy, dz);
       }
       if (perimeter <= holeSize) {
-        const v0 = loop[0] ?? 0
+        const v0 = loop[0] ?? 0;
         for (let k = 1; k < loop.length - 1; k++) {
-          newPolys.push(TRIANGLE_VERTS, v0, loop[k] ?? 0, loop[k + 1] ?? 0)
+          newPolys.push(TRIANGLE_VERTS, v0, loop[k] ?? 0, loop[k + 1] ?? 0);
         }
       }
     }
 
-    if (newPolys.length === 0) return sourceResult
-    const mergedPolys = new Uint32Array([...polys, ...newPolys])
-    const outputPd = vtk.Common.DataModel.vtkPolyData.newInstance()
-    outputPd.getPoints().setData(new Float32Array(inPoints), XYZ_COMPONENTS)
-    outputPd.getPolys().setData(mergedPolys)
-    return { output: outputPd, isFilter: false }
+    if (newPolys.length === 0) return sourceResult;
+    const mergedPolys = new Uint32Array([...polys, ...newPolys]);
+    const outputPd = vtk.Common.DataModel.vtkPolyData.newInstance();
+    outputPd.getPoints().setData(new Float32Array(inPoints), XYZ_COMPONENTS);
+    outputPd.getPolys().setData(mergedPolys);
+    return { output: outputPd, isFilter: false };
   }
 }

--- a/packages/react-pyvista/src/types.ts
+++ b/packages/react-pyvista/src/types.ts
@@ -1,123 +1,123 @@
 export interface LightConfig {
-  type: string
-  position: [number, number, number]
-  focalPoint: [number, number, number]
-  color: [number, number, number]
-  intensity: number
-  positional: boolean
-  coneAngle: number
-  coneFalloff: number
-  attenuationValues: [number, number, number]
+  type: string;
+  position: [number, number, number];
+  focalPoint: [number, number, number];
+  color: [number, number, number];
+  intensity: number;
+  positional: boolean;
+  coneAngle: number;
+  coneFalloff: number;
+  attenuationValues: [number, number, number];
 }
 
 export interface NormalsConfig {
-  computePointNormals: boolean
-  computeCellNormals: boolean
+  computePointNormals: boolean;
+  computeCellNormals: boolean;
 }
 
 export interface PointDataArray {
-  numberOfComponents: number
-  values: number[]
-  name: string
+  numberOfComponents: number;
+  values: number[];
+  name: string;
 }
 
 export interface FilterConfig {
-  type: string
-  shrinkFactor?: number
-  radius?: number
-  numberOfSides?: number
-  normal?: [number, number, number]
-  origin?: [number, number, number]
-  invert?: boolean
-  values?: number[]
-  scalarName?: string
-  scalarData?: number[]
-  holeSize?: number
+  type: string;
+  shrinkFactor?: number;
+  radius?: number;
+  numberOfSides?: number;
+  normal?: [number, number, number];
+  origin?: [number, number, number];
+  invert?: boolean;
+  values?: number[];
+  scalarName?: string;
+  scalarData?: number[];
+  holeSize?: number;
 }
 
 export interface SourceConfig {
-  type: string
-  center?: [number, number, number]
-  radius?: number
-  thetaResolution?: number
-  phiResolution?: number
-  height?: number
-  resolution?: number
-  xLength?: number
-  yLength?: number
-  zLength?: number
-  innerRadius?: number
-  outerRadius?: number
-  tipLength?: number
-  tipRadius?: number
-  shaftRadius?: number
-  point1?: [number, number, number]
-  point2?: [number, number, number]
-  origin?: [number, number, number]
-  normal?: [number, number, number]
-  points?: number[]
-  polys?: number[]
-  data?: string
-  pointData?: PointDataArray[]
-  tCoords?: number[]
-  filters?: FilterConfig[]
+  type: string;
+  center?: [number, number, number];
+  radius?: number;
+  thetaResolution?: number;
+  phiResolution?: number;
+  height?: number;
+  resolution?: number;
+  xLength?: number;
+  yLength?: number;
+  zLength?: number;
+  innerRadius?: number;
+  outerRadius?: number;
+  tipLength?: number;
+  tipRadius?: number;
+  shaftRadius?: number;
+  point1?: [number, number, number];
+  point2?: [number, number, number];
+  origin?: [number, number, number];
+  normal?: [number, number, number];
+  points?: number[];
+  polys?: number[];
+  data?: string;
+  pointData?: PointDataArray[];
+  tCoords?: number[];
+  filters?: FilterConfig[];
 }
 
 export interface EdgesConfig {
-  color: [number, number, number]
+  color: [number, number, number];
 }
 
 export interface PbrConfig {
-  metallic: number
-  roughness: number
+  metallic: number;
+  roughness: number;
 }
 
 export interface TextureConfig {
-  url: string
+  url: string;
 }
 
 export interface ActorConfig {
-  source: SourceConfig
-  color: [number, number, number]
-  opacity: number
-  style: string
-  shading?: string
-  edges?: EdgesConfig
-  pbr?: PbrConfig
-  normals?: NormalsConfig
-  actorType?: string
-  renderPointsAsSpheres?: boolean
-  pointSize?: number
-  texture?: TextureConfig
+  source: SourceConfig;
+  color: [number, number, number];
+  opacity: number;
+  style: string;
+  shading?: string;
+  edges?: EdgesConfig;
+  pbr?: PbrConfig;
+  normals?: NormalsConfig;
+  actorType?: string;
+  renderPointsAsSpheres?: boolean;
+  pointSize?: number;
+  texture?: TextureConfig;
 }
 
 export interface CameraConfig {
-  position?: [number, number, number]
-  focalPoint?: [number, number, number]
-  viewUp?: [number, number, number]
-  viewAngle?: number
-  clippingRange?: [number, number]
-  parallelProjection?: boolean
-  viewVector?: [number, number, number]
+  position?: [number, number, number];
+  focalPoint?: [number, number, number];
+  viewUp?: [number, number, number];
+  viewAngle?: number;
+  clippingRange?: [number, number];
+  parallelProjection?: boolean;
+  viewVector?: [number, number, number];
 }
 
 export interface TextActorConfig {
-  text: string
-  position: [number, number]
-  color: [number, number, number]
-  opacity: number
-  fontSize: number
-  bold: boolean
-  italic: boolean
+  text: string;
+  position: [number, number];
+  color: [number, number, number];
+  opacity: number;
+  fontSize: number;
+  bold: boolean;
+  italic: boolean;
 }
 
 export interface SceneData {
-  containerId: string
-  background: [number, number, number]
-  lightingMode: string | undefined
-  lights: LightConfig[]
-  actors: ActorConfig[]
-  textActors?: TextActorConfig[]
-  axes: boolean
-  camera?: CameraConfig
+  containerId: string;
+  background: [number, number, number];
+  lightingMode: string | undefined;
+  lights: LightConfig[];
+  actors: ActorConfig[];
+  textActors?: TextActorConfig[];
+  axes: boolean;
+  camera?: CameraConfig;
 }

--- a/packages/react-pyvista/src/types.ts
+++ b/packages/react-pyvista/src/types.ts
@@ -1,0 +1,123 @@
+export interface LightConfig {
+  type: string
+  position: [number, number, number]
+  focalPoint: [number, number, number]
+  color: [number, number, number]
+  intensity: number
+  positional: boolean
+  coneAngle: number
+  coneFalloff: number
+  attenuationValues: [number, number, number]
+}
+
+export interface NormalsConfig {
+  computePointNormals: boolean
+  computeCellNormals: boolean
+}
+
+export interface PointDataArray {
+  numberOfComponents: number
+  values: number[]
+  name: string
+}
+
+export interface FilterConfig {
+  type: string
+  shrinkFactor?: number
+  radius?: number
+  numberOfSides?: number
+  normal?: [number, number, number]
+  origin?: [number, number, number]
+  invert?: boolean
+  values?: number[]
+  scalarName?: string
+  scalarData?: number[]
+  holeSize?: number
+}
+
+export interface SourceConfig {
+  type: string
+  center?: [number, number, number]
+  radius?: number
+  thetaResolution?: number
+  phiResolution?: number
+  height?: number
+  resolution?: number
+  xLength?: number
+  yLength?: number
+  zLength?: number
+  innerRadius?: number
+  outerRadius?: number
+  tipLength?: number
+  tipRadius?: number
+  shaftRadius?: number
+  point1?: [number, number, number]
+  point2?: [number, number, number]
+  origin?: [number, number, number]
+  normal?: [number, number, number]
+  points?: number[]
+  polys?: number[]
+  data?: string
+  pointData?: PointDataArray[]
+  tCoords?: number[]
+  filters?: FilterConfig[]
+}
+
+export interface EdgesConfig {
+  color: [number, number, number]
+}
+
+export interface PbrConfig {
+  metallic: number
+  roughness: number
+}
+
+export interface TextureConfig {
+  url: string
+}
+
+export interface ActorConfig {
+  source: SourceConfig
+  color: [number, number, number]
+  opacity: number
+  style: string
+  shading?: string
+  edges?: EdgesConfig
+  pbr?: PbrConfig
+  normals?: NormalsConfig
+  actorType?: string
+  renderPointsAsSpheres?: boolean
+  pointSize?: number
+  texture?: TextureConfig
+}
+
+export interface CameraConfig {
+  position?: [number, number, number]
+  focalPoint?: [number, number, number]
+  viewUp?: [number, number, number]
+  viewAngle?: number
+  clippingRange?: [number, number]
+  parallelProjection?: boolean
+  viewVector?: [number, number, number]
+}
+
+export interface TextActorConfig {
+  text: string
+  position: [number, number]
+  color: [number, number, number]
+  opacity: number
+  fontSize: number
+  bold: boolean
+  italic: boolean
+}
+
+export interface SceneData {
+  containerId: string
+  background: [number, number, number]
+  lightingMode: string | undefined
+  lights: LightConfig[]
+  actors: ActorConfig[]
+  textActors?: TextActorConfig[]
+  axes: boolean
+  camera?: CameraConfig
+}

--- a/packages/react-pyvista/src/vtkLoader.ts
+++ b/packages/react-pyvista/src/vtkLoader.ts
@@ -1,26 +1,28 @@
-export const DEFAULT_VTK_CDN = 'https://unpkg.com/vtk.js@29.5.0'
+export const DEFAULT_VTK_CDN = "https://unpkg.com/vtk.js@29.5.0";
 
-let loadPromise: Promise<void> | null = null
+let loadPromise: Promise<void> | null = null;
 
 export function loadVtkJs(cdnUrl = DEFAULT_VTK_CDN): Promise<void> {
-  if (typeof window === 'undefined') {
-    return Promise.reject(new Error('vtk.js requires a browser environment'))
+  if (typeof window === "undefined") {
+    return Promise.reject(new Error("vtk.js requires a browser environment"));
   }
   if ((window as unknown as { vtk?: unknown }).vtk) {
-    return Promise.resolve()
+    return Promise.resolve();
   }
-  if (loadPromise) return loadPromise
+  if (loadPromise) return loadPromise;
 
   loadPromise = new Promise((resolve, reject) => {
-    const script = document.createElement('script')
-    script.src = cdnUrl
-    script.addEventListener('load', () => { resolve() })
-    script.addEventListener('error', () => {
-      loadPromise = null
-      reject(new Error(`Failed to load vtk.js from ${cdnUrl}`))
-    })
-    document.head.appendChild(script)
-  })
+    const script = document.createElement("script");
+    script.src = cdnUrl;
+    script.addEventListener("load", () => {
+      resolve();
+    });
+    script.addEventListener("error", () => {
+      loadPromise = null;
+      reject(new Error(`Failed to load vtk.js from ${cdnUrl}`));
+    });
+    document.head.appendChild(script);
+  });
 
-  return loadPromise
+  return loadPromise;
 }

--- a/packages/react-pyvista/src/vtkLoader.ts
+++ b/packages/react-pyvista/src/vtkLoader.ts
@@ -1,0 +1,26 @@
+export const DEFAULT_VTK_CDN = 'https://unpkg.com/vtk.js@29.5.0'
+
+let loadPromise: Promise<void> | null = null
+
+export function loadVtkJs(cdnUrl = DEFAULT_VTK_CDN): Promise<void> {
+  if (typeof window === 'undefined') {
+    return Promise.reject(new Error('vtk.js requires a browser environment'))
+  }
+  if ((window as unknown as { vtk?: unknown }).vtk) {
+    return Promise.resolve()
+  }
+  if (loadPromise) return loadPromise
+
+  loadPromise = new Promise((resolve, reject) => {
+    const script = document.createElement('script')
+    script.src = cdnUrl
+    script.addEventListener('load', () => { resolve() })
+    script.addEventListener('error', () => {
+      loadPromise = null
+      reject(new Error(`Failed to load vtk.js from ${cdnUrl}`))
+    })
+    document.head.appendChild(script)
+  })
+
+  return loadPromise
+}

--- a/packages/react-pyvista/src/workers/pyodide.worker.ts
+++ b/packages/react-pyvista/src/workers/pyodide.worker.ts
@@ -8,59 +8,59 @@
  */
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const loadPyodide: (options?: Record<string, unknown>) => Promise<any>
+declare const loadPyodide: (options?: Record<string, unknown>) => Promise<any>;
 
 // importScripts is available in classic workers; type it explicitly
-declare function importScripts(...urls: string[]): void
+declare function importScripts(...urls: string[]): void;
 
-const DEFAULT_PYODIDE_INDEX =
-  'https://cdn.jsdelivr.net/pyodide/stable/full/'
+const DEFAULT_PYODIDE_INDEX = "https://cdn.jsdelivr.net/pyodide/stable/full/";
 
 interface InitMessage {
-  type: 'init'
-  packages: string[]
-  pyodideUrl?: string
+  type: "init";
+  packages: string[];
+  pyodideUrl?: string;
 }
 
 interface RunMessage {
-  type: 'run'
-  id: string
-  code: string
+  type: "run";
+  id: string;
+  code: string;
 }
 
-type WorkerInput = InitMessage | RunMessage
+type WorkerInput = InitMessage | RunMessage;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-let pyodide: any = null
+let pyodide: any = null;
 
 async function initialize(packages: string[], pyodideUrl?: string): Promise<void> {
-  const indexURL = pyodideUrl ?? DEFAULT_PYODIDE_INDEX
+  const indexUrl = pyodideUrl ?? DEFAULT_PYODIDE_INDEX;
 
   // Load Pyodide bootstrap
-  importScripts(indexURL + 'pyodide.js')
+  importScripts(`${indexUrl}pyodide.js`);
 
-  pyodide = await loadPyodide({ indexURL })
+  // biome-ignore lint/style/useNamingConvention: indexURL is required by the Pyodide API
+  pyodide = await loadPyodide({ indexURL: indexUrl });
 
   // Redirect stdout to main thread
   pyodide.setStdout({
     batched: (text: string) => {
-      self.postMessage({ type: 'stdout', text })
+      self.postMessage({ type: "stdout", text });
     },
-  })
+  });
   pyodide.setStderr({
     batched: (text: string) => {
-      self.postMessage({ type: 'stderr', text })
+      self.postMessage({ type: "stderr", text });
     },
-  })
+  });
 
   // Install pyvista-js
-  await pyodide.loadPackage('micropip')
-  const micropip = pyodide.pyimport('micropip')
-  await micropip.install('pyvista-js')
+  await pyodide.loadPackage("micropip");
+  const micropip = pyodide.pyimport("micropip");
+  await micropip.install("pyvista-js");
 
   // Install any additional packages requested by the caller
   if (packages.length > 0) {
-    await micropip.install(packages)
+    await micropip.install(packages);
   }
 
   // Intercept Plotter.show() so it emits scene JSON instead of trying to
@@ -78,64 +78,63 @@ def _rp_capturing_show(self, *args, **kwargs):
     _rp_captured_scene = self.get_scene_dict()
 
 pv.Plotter.show = _rp_capturing_show
-`)
+`);
 
-  self.postMessage({ type: 'ready' })
+  self.postMessage({ type: "ready" });
 }
 
 async function run(id: string, code: string): Promise<void> {
   if (!pyodide) {
-    self.postMessage({ type: 'error', id, message: 'Pyodide is not initialised yet.' })
-    return
+    self.postMessage({ type: "error", id, message: "Pyodide is not initialised yet." });
+    return;
   }
 
   try {
     // Reset the captured scene before each run
-    await pyodide.runPythonAsync('_rp_captured_scene = None')
+    await pyodide.runPythonAsync("_rp_captured_scene = None");
 
     // Execute user code
-    await pyodide.runPythonAsync(code)
+    await pyodide.runPythonAsync(code);
 
     // Retrieve scene JSON
     const sceneJson: string = await pyodide.runPythonAsync(
       '_json.dumps(_rp_captured_scene) if _rp_captured_scene is not None else "null"',
-    )
+    );
 
-    if (sceneJson === 'null') {
+    if (sceneJson === "null") {
       self.postMessage({
-        type: 'error',
+        type: "error",
         id,
-        message:
-          'No scene was captured. Make sure your code calls plotter.show().',
-      })
+        message: "No scene was captured. Make sure your code calls plotter.show().",
+      });
     } else {
-      self.postMessage({ type: 'scene', id, data: JSON.parse(sceneJson) })
+      self.postMessage({ type: "scene", id, data: JSON.parse(sceneJson) });
     }
   } catch (err: unknown) {
     self.postMessage({
-      type: 'error',
+      type: "error",
       id,
       message: err instanceof Error ? err.message : String(err),
-    })
+    });
   }
 }
 
-self.addEventListener('message', (e: MessageEvent<WorkerInput>) => {
-  const msg = e.data
-  if (msg.type === 'init') {
+self.addEventListener("message", (e: MessageEvent<WorkerInput>) => {
+  const msg = e.data;
+  if (msg.type === "init") {
     initialize(msg.packages, msg.pyodideUrl).catch((err: unknown) => {
       self.postMessage({
-        type: 'error',
+        type: "error",
         message: `Pyodide initialisation failed: ${String(err)}`,
-      })
-    })
-  } else if (msg.type === 'run') {
+      });
+    });
+  } else if (msg.type === "run") {
     run(msg.id, msg.code).catch((err: unknown) => {
       self.postMessage({
-        type: 'error',
+        type: "error",
         id: msg.id,
         message: String(err),
-      })
-    })
+      });
+    });
   }
-})
+});

--- a/packages/react-pyvista/src/workers/pyodide.worker.ts
+++ b/packages/react-pyvista/src/workers/pyodide.worker.ts
@@ -1,0 +1,141 @@
+/**
+ * Pyodide Web Worker for react-pyvista.
+ *
+ * This worker loads Pyodide, installs pyvista-js via micropip, and executes
+ * Python code on behalf of the usePyVista hook. Plotter.show() is intercepted
+ * to capture scene JSON and postMessage it to the main thread instead of
+ * attempting DOM rendering.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const loadPyodide: (options?: Record<string, unknown>) => Promise<any>
+
+// importScripts is available in classic workers; type it explicitly
+declare function importScripts(...urls: string[]): void
+
+const DEFAULT_PYODIDE_INDEX =
+  'https://cdn.jsdelivr.net/pyodide/stable/full/'
+
+interface InitMessage {
+  type: 'init'
+  packages: string[]
+  pyodideUrl?: string
+}
+
+interface RunMessage {
+  type: 'run'
+  id: string
+  code: string
+}
+
+type WorkerInput = InitMessage | RunMessage
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let pyodide: any = null
+
+async function initialize(packages: string[], pyodideUrl?: string): Promise<void> {
+  const indexURL = pyodideUrl ?? DEFAULT_PYODIDE_INDEX
+
+  // Load Pyodide bootstrap
+  importScripts(indexURL + 'pyodide.js')
+
+  pyodide = await loadPyodide({ indexURL })
+
+  // Redirect stdout to main thread
+  pyodide.setStdout({
+    batched: (text: string) => {
+      self.postMessage({ type: 'stdout', text })
+    },
+  })
+  pyodide.setStderr({
+    batched: (text: string) => {
+      self.postMessage({ type: 'stderr', text })
+    },
+  })
+
+  // Install pyvista-js
+  await pyodide.loadPackage('micropip')
+  const micropip = pyodide.pyimport('micropip')
+  await micropip.install('pyvista-js')
+
+  // Install any additional packages requested by the caller
+  if (packages.length > 0) {
+    await micropip.install(packages)
+  }
+
+  // Intercept Plotter.show() so it emits scene JSON instead of trying to
+  // render into a DOM that doesn't exist inside a Web Worker.
+  await pyodide.runPythonAsync(`
+import pyvista_js as pv
+import json as _json
+
+_rp_captured_scene = None
+
+_rp_original_show = pv.Plotter.show
+
+def _rp_capturing_show(self, *args, **kwargs):
+    global _rp_captured_scene
+    _rp_captured_scene = self.get_scene_dict()
+
+pv.Plotter.show = _rp_capturing_show
+`)
+
+  self.postMessage({ type: 'ready' })
+}
+
+async function run(id: string, code: string): Promise<void> {
+  if (!pyodide) {
+    self.postMessage({ type: 'error', id, message: 'Pyodide is not initialised yet.' })
+    return
+  }
+
+  try {
+    // Reset the captured scene before each run
+    await pyodide.runPythonAsync('_rp_captured_scene = None')
+
+    // Execute user code
+    await pyodide.runPythonAsync(code)
+
+    // Retrieve scene JSON
+    const sceneJson: string = await pyodide.runPythonAsync(
+      '_json.dumps(_rp_captured_scene) if _rp_captured_scene is not None else "null"',
+    )
+
+    if (sceneJson === 'null') {
+      self.postMessage({
+        type: 'error',
+        id,
+        message:
+          'No scene was captured. Make sure your code calls plotter.show().',
+      })
+    } else {
+      self.postMessage({ type: 'scene', id, data: JSON.parse(sceneJson) })
+    }
+  } catch (err: unknown) {
+    self.postMessage({
+      type: 'error',
+      id,
+      message: err instanceof Error ? err.message : String(err),
+    })
+  }
+}
+
+self.addEventListener('message', (e: MessageEvent<WorkerInput>) => {
+  const msg = e.data
+  if (msg.type === 'init') {
+    initialize(msg.packages, msg.pyodideUrl).catch((err: unknown) => {
+      self.postMessage({
+        type: 'error',
+        message: `Pyodide initialisation failed: ${String(err)}`,
+      })
+    })
+  } else if (msg.type === 'run') {
+    run(msg.id, msg.code).catch((err: unknown) => {
+      self.postMessage({
+        type: 'error',
+        id: msg.id,
+        message: String(err),
+      })
+    })
+  }
+})

--- a/packages/react-pyvista/tsconfig.json
+++ b/packages/react-pyvista/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "declaration": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/packages/react-pyvista/vite.config.ts
+++ b/packages/react-pyvista/vite.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import dts from 'vite-plugin-dts'
+import { resolve } from 'path'
+
+export default defineConfig({
+  plugins: [
+    react(),
+    dts({ include: ['src'], insertTypesEntry: true }),
+  ],
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'src/index.ts'),
+      name: 'ReactPyVista',
+      fileName: 'react-pyvista',
+    },
+    rollupOptions: {
+      external: ['react', 'react-dom', 'react/jsx-runtime'],
+      output: {
+        globals: {
+          react: 'React',
+          'react-dom': 'ReactDOM',
+          'react/jsx-runtime': 'jsxRuntime',
+        },
+      },
+    },
+  },
+})

--- a/src/pyvista_js/plotter.py
+++ b/src/pyvista_js/plotter.py
@@ -832,7 +832,7 @@ class Plotter:
         True
 
         """
-        return self._renderer._build_scene_data()
+        return self._renderer.get_scene_dict()
 
     @property
     def actors(self) -> list[dict[str, Any]]:

--- a/src/pyvista_js/plotter.py
+++ b/src/pyvista_js/plotter.py
@@ -808,6 +808,32 @@ class Plotter:
         self._scalar_bar = None
         self._renderer.clear()
 
+    def get_scene_dict(self) -> dict[str, object]:
+        """Return the scene as a JSON-serialisable dictionary.
+
+        This is the same data that ``show()`` passes to the vtk.js renderer.
+        It is useful when you need to transfer scene data to JavaScript without
+        triggering a DOM render — for example, inside a Pyodide Web Worker.
+
+        Returns
+        -------
+        dict
+            Scene configuration including background, lights, actors, camera, etc.
+
+        Examples
+        --------
+        >>> import pyvista_js as pv
+        >>> plotter = pv.Plotter()
+        >>> _ = plotter.add_mesh(pv.Sphere(), color='red')
+        >>> scene = plotter.get_scene_dict()
+        >>> isinstance(scene, dict)
+        True
+        >>> 'actors' in scene
+        True
+
+        """
+        return self._renderer._build_scene_data()
+
     @property
     def actors(self) -> list[dict[str, Any]]:
         """Return the list of actors in the plotter."""

--- a/src/pyvista_js/rendering.py
+++ b/src/pyvista_js/rendering.py
@@ -760,6 +760,17 @@ class _BaseHTMLRenderer:
 
         return scene
 
+    def get_scene_dict(self) -> dict[str, object]:
+        """Return the scene as a JSON-serializable dictionary.
+
+        Returns
+        -------
+        dict
+            Scene configuration including background, lights, actors, camera, etc.
+
+        """
+        return self._build_scene_data()
+
     def _generate_html(self) -> str:
         """Generate HTML fragment with embedded vtk.js JavaScript."""
         import json as _json  # noqa: PLC0415

--- a/src/pyvista_js/rendering.py
+++ b/src/pyvista_js/rendering.py
@@ -1656,6 +1656,26 @@ class MockRenderer:
             return np.zeros((height, width, channels), dtype=np.uint8)
         return None
 
+    def get_scene_dict(self) -> dict[str, object]:
+        """Return a minimal scene dictionary for testing.
+
+        Returns
+        -------
+        dict
+            Empty scene dictionary with no actors.
+
+        """
+        return {
+            "containerId": "",
+            "background": [0.0, 0.0, 0.0],
+            "lights": [],
+            "actors": [],
+            "textActors": [],
+            "axes": False,
+            "camera": {},
+            "lightingMode": "default",
+        }
+
 
 def get_renderer(
     lighting: str | None = "default",


### PR DESCRIPTION
## Summary

- Add `packages/react-pyvista` as a new monorepo package inspired by [react-py](https://elilambnz.github.io/react-py/)
- `PyVistaViewer` component renders `SceneData` JSON via vtk.js loaded from CDN
- `usePyVista` hook executes Python code in a Pyodide Web Worker and captures scene output
- `PyVistaProvider` allows configuring vtk.js and Pyodide CDN URLs per application
- Add `get_scene_dict()` public API to `pyvista_js.Plotter` as the Python/JS bridge
- Add npm workspaces to root `package.json` to enable monorepo structure
- Extend `biome.jsonc` to lint and format `packages/react-pyvista/src/**/*.{ts,tsx}` with all built-in React rules enabled (hooks dependency checking, JSX rules, etc.)