### PR TITLE
feat: add terraform config to protect main branch

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,6 @@
+# Terraform
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+tfplan

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,30 @@
+# Terraform Branch Protection
+
+This directory contains Terraform configuration to manage branch protection
+rules on the `main` branch as infrastructure-as-code.
+
+## Resources
+
+- `github_branch_protection.main` — requires a pull request with code owner
+  review, enforces status checks (`lint`, `js-check`, `test`), keeps the branch
+  up to date before merging, and restricts direct pushes (admins included).
+- `github_repository_ruleset.conversation_resolution` — requires all review
+  conversations to be resolved before merging.
+
+## Usage
+
+```bash
+cd terraform
+terraform init
+terraform plan -var="github_token=<your-token>"
+terraform apply -var="github_token=<your-token>"
+```
+
+## Variables
+
+| Name              | Description                                          | Default       |
+| ----------------- | ---------------------------------------------------- | ------------- |
+| `github_token`    | GitHub personal access token with `repo:admin` scope | _(required)_  |
+| `github_owner`    | GitHub repository owner                              | `tkoyama010`  |
+| `github_repository` | GitHub repository name                             | `pyvista-js`  |
+| `branch_name`     | Branch to protect                                    | `main`        |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -22,9 +22,9 @@ terraform apply -var="github_token=<your-token>"
 
 ## Variables
 
-| Name              | Description                                          | Default       |
+| Name | Description | Default |
 | ----------------- | ---------------------------------------------------- | ------------- |
-| `github_token`    | GitHub personal access token with `repo:admin` scope | _(required)_  |
-| `github_owner`    | GitHub repository owner                              | `tkoyama010`  |
-| `github_repository` | GitHub repository name                             | `pyvista-js`  |
-| `branch_name`     | Branch to protect                                    | `main`        |
+| `github_token` | GitHub personal access token with `repo:admin` scope | _(required)_ |
+| `github_owner` | GitHub repository owner | `tkoyama010` |
+| `github_repository` | GitHub repository name | `pyvista-js` |
+| `branch_name` | Branch to protect | `main` |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,50 @@
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}
+
+# Branch protection on main
+resource "github_branch_protection" "main" {
+  repository_id  = var.github_repository
+  pattern        = var.branch_name
+  enforce_admins = true
+
+  required_pull_request_reviews {
+    require_code_owner_reviews = true
+  }
+
+  required_status_checks {
+    strict   = true
+    contexts = ["lint", "js-check", "test"]
+  }
+}
+
+# Require conversation resolution
+resource "github_repository_ruleset" "conversation_resolution" {
+  repository  = var.github_repository
+  name        = "Require conversation resolution on main"
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["refs/heads/main"]
+      exclude = []
+    }
+  }
+
+  rules {
+    pull_request {
+      required_review_thread_resolution = true
+    }
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,23 @@
+variable "github_token" {
+  description = "GitHub personal access token with repo:admin scope"
+  type        = string
+  sensitive   = true
+}
+
+variable "github_owner" {
+  description = "GitHub repository owner"
+  type        = string
+  default     = "tkoyama010"
+}
+
+variable "github_repository" {
+  description = "GitHub repository name"
+  type        = string
+  default     = "pyvista-js"
+}
+
+variable "branch_name" {
+  description = "Branch to protect"
+  type        = string
+  default     = "main"
+}


### PR DESCRIPTION
## Summary

Adds Terraform configuration using the [GitHub provider](https://registry.terraform.io/providers/integrations/github) (`~> 6.0`) to enforce branch protection rules on the `main` branch as infrastructure-as-code.

Closes #515.

## Usage

```bash
cd terraform
terraform init
terraform plan -var="github_token=<your-token>"
terraform apply -var="github_token=<your-token>"
```