### PR TITLE
chore: sync Terraform with current GitHub repository settings

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -14,9 +14,68 @@ provider "github" {
   owner = var.github_owner
 }
 
+# Repository settings
+resource "github_repository" "main" {
+  name                        = var.github_repository
+  description                 = "PyVista-like API for vtk.js"
+  homepage_url                = "https://pyvista-js.readthedocs.io/en/latest/?badge=latest"
+  visibility                  = "public"
+  has_issues                  = true
+  has_projects                = true
+  has_wiki                    = true
+  has_discussions             = true
+  delete_branch_on_merge      = true
+  allow_squash_merge          = true
+  allow_merge_commit          = false
+  allow_rebase_merge          = false
+  allow_auto_merge            = false
+  allow_update_branch         = true
+  squash_merge_commit_title   = "PR_TITLE"
+  squash_merge_commit_message = "BLANK"
+  merge_commit_title          = "MERGE_MESSAGE"
+  merge_commit_message        = "PR_TITLE"
+  topics = [
+    "3d",
+    "fem",
+    "finite-element-analysis",
+    "finite-elements",
+    "hacktoberfest",
+    "mesh",
+    "mesh-processing",
+    "meshviewer",
+    "open-science",
+    "plotting",
+    "python",
+    "pyvista",
+    "scientific-research",
+    "scientific-visualization",
+    "visualization",
+    "vtk",
+    "vtk-js",
+  ]
+
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+    secret_scanning_non_provider_patterns {
+      status = "disabled"
+    }
+  }
+}
+
+# Dependabot security alerts
+resource "github_repository_vulnerability_alerts" "main" {
+  repository = github_repository.main.name
+  enabled    = true
+}
+
 # Branch protection on main
 resource "github_branch_protection" "main" {
-  repository_id  = var.github_repository
+  repository_id  = github_repository.main.name
   pattern        = var.branch_name
   enforce_admins = true
 
@@ -26,13 +85,94 @@ resource "github_branch_protection" "main" {
 
   required_status_checks {
     strict   = true
-    contexts = ["lint", "js-check", "test"]
+    contexts = ["lint", "js-check"]
   }
 }
 
-# Require conversation resolution
+# Main ruleset: deletion, non-fast-forward, PR reviews, status checks
+resource "github_repository_ruleset" "main" {
+  repository  = github_repository.main.name
+  name        = "main"
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  rules {
+    deletion         = true
+    non_fast_forward = true
+
+    pull_request {
+      required_approving_review_count   = 1
+      require_code_owner_review         = false
+      dismiss_stale_reviews_on_push     = false
+      require_last_push_approval        = false
+      required_review_thread_resolution = false
+      allowed_merge_methods = [
+        "merge",
+        "squash",
+        "rebase",
+      ]
+    }
+
+    required_status_checks {
+      strict_required_status_checks_policy = true
+      do_not_enforce_on_create             = false
+
+      required_check {
+        context        = "test (macos-latest, 3.12)"
+        integration_id = 15368
+      }
+      required_check {
+        context        = "test (macos-latest, 3.13)"
+        integration_id = 15368
+      }
+      required_check {
+        context        = "test (macos-latest, 3.14)"
+        integration_id = 15368
+      }
+      required_check {
+        context        = "test (ubuntu-latest, 3.12)"
+        integration_id = 15368
+      }
+      required_check {
+        context        = "test (ubuntu-latest, 3.13)"
+        integration_id = 15368
+      }
+      required_check {
+        context        = "test (ubuntu-latest, 3.14)"
+        integration_id = 15368
+      }
+      required_check {
+        context        = "test (windows-latest, 3.12)"
+        integration_id = 15368
+      }
+      required_check {
+        context        = "test (windows-latest, 3.13)"
+        integration_id = 15368
+      }
+      required_check {
+        context        = "test (windows-latest, 3.14)"
+        integration_id = 15368
+      }
+      required_check {
+        context = "docs/readthedocs.org:pyvista-js"
+      }
+      required_check {
+        context = "docs/readthedocs.org:pyvista-js-ja"
+      }
+    }
+  }
+}
+
+# Require conversation resolution on main
 resource "github_repository_ruleset" "conversation_resolution" {
-  repository  = var.github_repository
+  repository  = github_repository.main.name
   name        = "Require conversation resolution on main"
   target      = "branch"
   enforcement = "active"


### PR DESCRIPTION
## Summary

Syncs the Terraform configuration with the current GitHub repository settings that were changed outside of Terraform.

## Changes

- **Add `github_repository` resource** — manages repo-level settings: description, visibility, merge methods (squash only), topics, discussions, security scanning (secret scanning + push protection), `delete_branch_on_merge`, `allow_update_branch`, etc.
- **Add `github_repository_vulnerability_alerts`** — enables Dependabot security alerts.
- **Add `github_repository_ruleset.main`** — manages the existing "main" ruleset: deletion, non-fast-forward, PR requiring 1 approval, and 11 required status checks (test matrix across macOS/Ubuntu/Windows x Python 3.12/3.13/3.14 + ReadTheDocs docs builds).
- **Fix `github_branch_protection` status checks** — removed stale `test` context; now `["lint", "js-check"]` to match GitHub.
- All resources now reference `github_repository.main.name` for proper dependency ordering.

## Post-merge steps

Import the new resources into Terraform state before running `terraform apply`:

```bash
terraform import github_repository.main pyvista-js
terraform import github_repository_vulnerability_alerts.main pyvista-js
terraform import github_repository_ruleset.main pyvista-js:15080364
```