### PR TITLE
fix: resolve Terraform drift and restrict ruleset to main branch

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -61,9 +61,6 @@ resource "github_repository" "main" {
     secret_scanning_push_protection {
       status = "enabled"
     }
-    secret_scanning_non_provider_patterns {
-      status = "disabled"
-    }
   }
 }
 
@@ -80,7 +77,8 @@ resource "github_branch_protection" "main" {
   enforce_admins = true
 
   required_pull_request_reviews {
-    require_code_owner_reviews = true
+    require_code_owner_reviews      = true
+    required_approving_review_count = 0
   }
 
   required_status_checks {
@@ -98,7 +96,7 @@ resource "github_repository_ruleset" "main" {
 
   conditions {
     ref_name {
-      include = ["~ALL"]
+      include = ["refs/heads/main"]
       exclude = []
     }
   }


### PR DESCRIPTION
## Summary

Follow-up to #519 that fixes remaining drift and a ruleset scoping issue.

## Post-merge

The ruleset was already updated via the GitHub API to use `refs/heads/main`. After merge, run `terraform plan` to confirm zero drift.