### PR TITLE
chore: sync Terraform with current GitHub repository settings

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -5,11 +5,13 @@ rules on the `main` branch as infrastructure-as-code.
 
 ## Resources
 
-- `github_branch_protection.main` — requires a pull request with code owner
-  review, enforces status checks (`lint`, `js-check`, `test`), keeps the branch
-  up to date before merging, and restricts direct pushes (admins included).
-- `github_repository_ruleset.conversation_resolution` — requires all review
-  conversations to be resolved before merging.
+- `github_repository.main` — repository settings (description, topics, merge
+  strategy, security & analysis).
+- `github_repository_vulnerability_alerts.main` — enables Dependabot security
+  alerts.
+- `github_repository_ruleset.main` — enforces deletion and non-fast-forward
+  protection, requires pull request reviews (0 approving reviews), and
+  requires status checks (`test` matrix, Read the Docs builds) on `main`.
 
 ## Usage
 
@@ -41,4 +43,3 @@ tflint -f compact
 | `github_token` | GitHub personal access token with `repo:admin` scope | _(required)_ |
 | `github_owner` | GitHub repository owner | `tkoyama010` |
 | `github_repository` | GitHub repository name | `pyvista-js` |
-| `branch_name` | Branch to protect | `main` |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -61,9 +61,6 @@ resource "github_repository" "main" {
     secret_scanning_push_protection {
       status = "enabled"
     }
-    secret_scanning_non_provider_patterns {
-      status = "disabled"
-    }
   }
 }
 
@@ -71,22 +68,6 @@ resource "github_repository" "main" {
 resource "github_repository_vulnerability_alerts" "main" {
   repository = github_repository.main.name
   enabled    = true
-}
-
-# Branch protection on main
-resource "github_branch_protection" "main" {
-  repository_id  = github_repository.main.name
-  pattern        = var.branch_name
-  enforce_admins = true
-
-  required_pull_request_reviews {
-    require_code_owner_reviews = true
-  }
-
-  required_status_checks {
-    strict   = true
-    contexts = ["lint", "js-check"]
-  }
 }
 
 # Main ruleset: deletion, non-fast-forward, PR reviews, status checks
@@ -98,7 +79,7 @@ resource "github_repository_ruleset" "main" {
 
   conditions {
     ref_name {
-      include = ["~ALL"]
+      include = ["refs/heads/main"]
       exclude = []
     }
   }
@@ -108,7 +89,7 @@ resource "github_repository_ruleset" "main" {
     non_fast_forward = true
 
     pull_request {
-      required_approving_review_count   = 1
+      required_approving_review_count   = 0
       require_code_owner_review         = false
       dismiss_stale_reviews_on_push     = false
       require_last_push_approval        = false
@@ -166,27 +147,6 @@ resource "github_repository_ruleset" "main" {
       required_check {
         context = "docs/readthedocs.org:pyvista-js-ja"
       }
-    }
-  }
-}
-
-# Require conversation resolution on main
-resource "github_repository_ruleset" "conversation_resolution" {
-  repository  = github_repository.main.name
-  name        = "Require conversation resolution on main"
-  target      = "branch"
-  enforcement = "active"
-
-  conditions {
-    ref_name {
-      include = ["refs/heads/main"]
-      exclude = []
-    }
-  }
-
-  rules {
-    pull_request {
-      required_review_thread_resolution = true
     }
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -15,9 +15,3 @@ variable "github_repository" {
   type        = string
   default     = "pyvista-js"
 }
-
-variable "branch_name" {
-  description = "Branch to protect"
-  type        = string
-  default     = "main"
-}


### PR DESCRIPTION
## Summary

Sync the Terraform configuration with the current GitHub repository settings to eliminate drift.

## Changes

- **Remove  resource** — branch protection was removed on GitHub; the  ruleset now solely governs branch rules.
- **Remove ** — the separate conversation-resolution ruleset was removed on GitHub.
- **Update ** to match GitHub:
  - :  → 
  - :  → 
- **Remove  block** —  is the default and the provider doesn't read it back, causing perpetual drift.
- **Remove unused  variable** (only referenced by the removed branch protection resource).
- **Update ** to reflect the current resource inventory.

## Verification

```
terraform plan
→ No changes. Your infrastructure matches the configuration.
```