### PR TITLE
chore: add .envrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ assets/*.gif
 node_modules/
 src/pyvista_js/templates/renderer.js
 .aider*
+
+# direnv (contains secrets)
+.envrc


### PR DESCRIPTION
## Summary

Add `.envrc` to `.gitignore` to prevent accidentally committing secrets.

`.envrc` is used by [direnv](https://direnv.net/) to load `TF_VAR_github_token` for Terraform and may contain sensitive tokens.