### PR TITLE
ci: add tfcmt to review terraform plan in PRs and apply on main

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -38,11 +38,12 @@ jobs:
         run: |
           set -eu
           TFCMT_VERSION=v4.14.15
-          curl -sSL "https://github.com/suzuki-shunsuke/tfcmt/releases/download/${TFCMT_VERSION}/tfcmt_linux_amd64.tar.gz" -o /tmp/tfcmt.tar.gz
-          curl -sSL "https://github.com/suzuki-shunsuke/tfcmt/releases/download/${TFCMT_VERSION}/tfcmt_4.14.15_checksums.txt" -o /tmp/checksums.txt
-          grep 'tfcmt_linux_amd64.tar.gz' /tmp/checksums.txt | sha256sum -c -
-          tar xzf /tmp/tfcmt.tar.gz -C /tmp
-          sudo mv /tmp/tfcmt /usr/local/bin/tfcmt
+          cd /tmp
+          curl -sSL "https://github.com/suzuki-shunsuke/tfcmt/releases/download/${TFCMT_VERSION}/tfcmt_linux_amd64.tar.gz" -o tfcmt.tar.gz
+          curl -sSL "https://github.com/suzuki-shunsuke/tfcmt/releases/download/${TFCMT_VERSION}/tfcmt_4.14.15_checksums.txt" -o checksums.txt
+          grep 'tfcmt_linux_amd64\.tar\.gz$' checksums.txt | sha256sum -c -
+          tar xzf tfcmt.tar.gz
+          sudo mv tfcmt /usr/local/bin/tfcmt
           tfcmt --version
 
       - name: Terraform init
@@ -74,11 +75,12 @@ jobs:
         run: |
           set -eu
           TFCMT_VERSION=v4.14.15
-          curl -sSL "https://github.com/suzuki-shunsuke/tfcmt/releases/download/${TFCMT_VERSION}/tfcmt_linux_amd64.tar.gz" -o /tmp/tfcmt.tar.gz
-          curl -sSL "https://github.com/suzuki-shunsuke/tfcmt/releases/download/${TFCMT_VERSION}/tfcmt_4.14.15_checksums.txt" -o /tmp/checksums.txt
-          grep 'tfcmt_linux_amd64.tar.gz' /tmp/checksums.txt | sha256sum -c -
-          tar xzf /tmp/tfcmt.tar.gz -C /tmp
-          sudo mv /tmp/tfcmt /usr/local/bin/tfcmt
+          cd /tmp
+          curl -sSL "https://github.com/suzuki-shunsuke/tfcmt/releases/download/${TFCMT_VERSION}/tfcmt_linux_amd64.tar.gz" -o tfcmt.tar.gz
+          curl -sSL "https://github.com/suzuki-shunsuke/tfcmt/releases/download/${TFCMT_VERSION}/tfcmt_4.14.15_checksums.txt" -o checksums.txt
+          grep 'tfcmt_linux_amd64\.tar\.gz$' checksums.txt | sha256sum -c -
+          tar xzf tfcmt.tar.gz
+          sudo mv tfcmt /usr/local/bin/tfcmt
           tfcmt --version
 
       - name: Terraform init

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -39,10 +39,10 @@ jobs:
           set -eu
           TFCMT_VERSION=v4.14.15
           cd /tmp
-          curl -sSL "https://github.com/suzuki-shunsuke/tfcmt/releases/download/${TFCMT_VERSION}/tfcmt_linux_amd64.tar.gz" -o tfcmt.tar.gz
+          curl -sSL "https://github.com/suzuki-shunsuke/tfcmt/releases/download/${TFCMT_VERSION}/tfcmt_linux_amd64.tar.gz" -O
           curl -sSL "https://github.com/suzuki-shunsuke/tfcmt/releases/download/${TFCMT_VERSION}/tfcmt_4.14.15_checksums.txt" -o checksums.txt
           grep 'tfcmt_linux_amd64\.tar\.gz$' checksums.txt | sha256sum -c -
-          tar xzf tfcmt.tar.gz
+          tar xzf tfcmt_linux_amd64.tar.gz
           sudo mv tfcmt /usr/local/bin/tfcmt
           tfcmt --version
 
@@ -76,10 +76,10 @@ jobs:
           set -eu
           TFCMT_VERSION=v4.14.15
           cd /tmp
-          curl -sSL "https://github.com/suzuki-shunsuke/tfcmt/releases/download/${TFCMT_VERSION}/tfcmt_linux_amd64.tar.gz" -o tfcmt.tar.gz
+          curl -sSL "https://github.com/suzuki-shunsuke/tfcmt/releases/download/${TFCMT_VERSION}/tfcmt_linux_amd64.tar.gz" -O
           curl -sSL "https://github.com/suzuki-shunsuke/tfcmt/releases/download/${TFCMT_VERSION}/tfcmt_4.14.15_checksums.txt" -o checksums.txt
           grep 'tfcmt_linux_amd64\.tar\.gz$' checksums.txt | sha256sum -c -
-          tar xzf tfcmt.tar.gz
+          tar xzf tfcmt_linux_amd64.tar.gz
           sudo mv tfcmt /usr/local/bin/tfcmt
           tfcmt --version
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,92 @@
+name: Terraform
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'terraform/**'
+      - '.github/workflows/terraform.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'terraform/**'
+      - '.github/workflows/terraform.yml'
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          persist-credentials: false
+
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
+        with:
+          terraform_wrapper: false
+
+      - name: Install tfcmt
+        run: |
+          set -eu
+          TFCMT_VERSION=v4.14.15
+          curl -sSL "https://github.com/suzuki-shunsuke/tfcmt/releases/download/${TFCMT_VERSION}/tfcmt_linux_amd64.tar.gz" -o /tmp/tfcmt.tar.gz
+          curl -sSL "https://github.com/suzuki-shunsuke/tfcmt/releases/download/${TFCMT_VERSION}/tfcmt_4.14.15_checksums.txt" -o /tmp/checksums.txt
+          grep 'tfcmt_linux_amd64.tar.gz' /tmp/checksums.txt | sha256sum -c -
+          tar xzf /tmp/tfcmt.tar.gz -C /tmp
+          sudo mv /tmp/tfcmt /usr/local/bin/tfcmt
+          tfcmt --version
+
+      - name: Terraform init
+        run: terraform init
+        working-directory: terraform
+
+      - name: Terraform plan
+        run: tfcmt plan -- terraform plan -input=false -var="github_token=${{ secrets.TF_GITHUB_TOKEN }}"
+        working-directory: terraform
+        env:
+          TFCMT_GITHUB_TOKEN: ${{ github.token }}
+
+  apply:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          persist-credentials: false
+
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
+        with:
+          terraform_wrapper: false
+
+      - name: Install tfcmt
+        run: |
+          set -eu
+          TFCMT_VERSION=v4.14.15
+          curl -sSL "https://github.com/suzuki-shunsuke/tfcmt/releases/download/${TFCMT_VERSION}/tfcmt_linux_amd64.tar.gz" -o /tmp/tfcmt.tar.gz
+          curl -sSL "https://github.com/suzuki-shunsuke/tfcmt/releases/download/${TFCMT_VERSION}/tfcmt_4.14.15_checksums.txt" -o /tmp/checksums.txt
+          grep 'tfcmt_linux_amd64.tar.gz' /tmp/checksums.txt | sha256sum -c -
+          tar xzf /tmp/tfcmt.tar.gz -C /tmp
+          sudo mv /tmp/tfcmt /usr/local/bin/tfcmt
+          tfcmt --version
+
+      - name: Terraform init
+        run: terraform init
+        working-directory: terraform
+
+      - name: Terraform apply
+        run: tfcmt apply -- terraform apply -input=false -auto-approve -var="github_token=${{ secrets.TF_GITHUB_TOKEN }}"
+        working-directory: terraform
+        env:
+          TFCMT_GITHUB_TOKEN: ${{ github.token }}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -36,6 +36,34 @@ cd terraform
 tflint -f compact
 ```
 
+## CI Plan & Apply
+
+In addition to TFLint, the `Terraform` GitHub Actions workflow
+(`.github/workflows/terraform.yml`) automates `terraform plan` and
+`terraform apply` using [tfcmt](https://github.com/suzuki-shunsuke/tfcmt)
+so that plan output is posted directly as a PR comment for review.
+
+### Workflow jobs
+
+| Job    | Trigger                          | Action                                                |
+| ------ | -------------------------------- | ----------------------------------------------------- |
+| `plan` | `pull_request` targeting `main`  | Runs `terraform plan` and posts the result as a PR comment.  |
+| `apply`| `push` to `main`                 | Runs `terraform apply -auto-approve` and posts the result.   |
+
+Both jobs only run when files under `terraform/` or the workflow file itself
+change.
+
+### Required secret
+
+The workflow passes the `github_token` Terraform variable from the
+`TF_GITHUB_TOKEN` repository secret.  Create a GitHub personal access token
+(or fine-grained token) with `repo:admin` scope and add it as a repository
+secret named `TF_GITHUB_TOKEN`.
+
+> **Note:** tfcmt uses the auto-generated `GITHUB_TOKEN` (with
+> `pull-requests: write` permission) to post comments, so no extra token is
+> needed for commenting.
+
 ## Variables
 
 | Name | Description | Default |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -45,10 +45,10 @@ so that plan output is posted directly as a PR comment for review.
 
 ### Workflow jobs
 
-| Job    | Trigger                          | Action                                                |
+| Job | Trigger | Action |
 | ------ | -------------------------------- | ----------------------------------------------------- |
-| `plan` | `pull_request` targeting `main`  | Runs `terraform plan` and posts the result as a PR comment.  |
-| `apply`| `push` to `main`                 | Runs `terraform apply -auto-approve` and posts the result.   |
+| `plan` | `pull_request` targeting `main` | Runs `terraform plan` and posts the result as a PR comment. |
+| `apply`| `push` to `main` | Runs `terraform apply -auto-approve` and posts the result. |
 
 Both jobs only run when files under `terraform/` or the workflow file itself
 change.
@@ -56,7 +56,7 @@ change.
 ### Required secret
 
 The workflow passes the `github_token` Terraform variable from the
-`TF_GITHUB_TOKEN` repository secret.  Create a GitHub personal access token
+`TF_GITHUB_TOKEN` repository secret. Create a GitHub personal access token
 (or fine-grained token) with `repo:admin` scope and add it as a repository
 secret named `TF_GITHUB_TOKEN`.
 


### PR DESCRIPTION
Closes #525

## Required secret

Before the workflow can run, add a repository secret named `TF_GITHUB_TOKEN` containing a GitHub personal access token (or fine-grained token) with `repo:admin` scope. This is the same token used for local `terraform plan`/`apply`.