### PR TITLE
docs: add MADR badge to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -262,6 +262,8 @@ uv run tox -e docs
 
 ### Architecture Decision Records
 
+[![MADR](https://img.shields.io/badge/decisions-MADR_4.0.0-blue.svg)](https://github.com/tkoyama010/pyvista-js/tree/main/docs/decisions)
+
 Architecturally significant decisions are recorded as [MADR 4.0.0](https://adr.github.io/madr/) records in [`docs/decisions/`](../docs/decisions/). This captures the *why* behind a decision alongside the code it governs.
 
 To add a record:


### PR DESCRIPTION
## Description

Adds a `decisions-MADR_4.0.0` shields.io badge to the Architecture Decision Records section of CONTRIBUTING.md, linking to `docs/decisions/`. Placing the badge here — where contributors learn about the ADR workflow — is more contextually relevant than the README badge cluster.

Supersedes #550, which added the badge to README.md instead.

## Related Issue

Follow-up to #546.

## Type of Change

- [x] `docs`: Documentation changes

## Checklist

- [x] My PR title follows the [Conventional Commits](https://conventionalcommits.org) format
- [x] My code follows the project's code style (`mdformat`, `codespell` pass)

## Testing

- Ran `pre-commit run --files CONTRIBUTING.md` — all hooks pass.