### PR TITLE
ci: create PR for .pot files instead of pushing to main

### DIFF
--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   transifex:
@@ -23,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          persist-credentials: true  # zizmor: ignore[persist-credentials]
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
@@ -36,14 +37,15 @@ jobs:
       - name: Generate .pot files
         run: cd docs && make gettext
 
-      - name: Commit updated .pot files
-        run: |
-          git config user.name "transifex-integration[bot]"
-          git config user.email "transifex-integration[bot]@users.noreply.github.com"
-          git add docs/pot/
-          if git diff --cached --quiet; then
-            echo "No changes to .pot files."
-          else
-            git commit -m "chore: update pot files"
-            git push
-          fi
+      - name: Create pull request for updated .pot files
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
+        with:
+          commit-message: 'chore: update pot files'
+          branch: chore/update-pot-files
+          title: 'chore: update pot files'
+          body: |
+            Auto-generated pull request to update `.pot` files for Transifex translations.
+
+            Closes #552
+          add-paths: |
+            docs/pot/


### PR DESCRIPTION
## Description

The "Transifex Sync" workflow fails at the "Commit updated .pot files" step because direct pushes to `main` are blocked by repository rules (changes to `main` must be made through a pull request). This PR updates `.github/workflows/transifex.yml` to use [`peter-evans/create-pull-request`](https://github.com/peter-evans/create-pull-request) (v8.1.1, pinned by SHA) to open a pull request for the generated `.pot` files instead of pushing directly to `main`.

### Changes

- Replaced the manual `git commit` + `git push` step with the `peter-evans/create-pull-request` action, which creates/updates a `chore/update-pot-files` branch and opens a PR targeting `main`.
- Added `pull-requests: write` permission (required to open pull requests).
- Switched `persist-credentials` from `true` to `false` since the manual push is no longer performed (the action handles its own authentication via `GITHUB_TOKEN`), removing the `zizmor: ignore[persist-credentials]` suppression.

The action is a no-op when there are no changes to `docs/pot/`, preserving the previous "No changes to .pot files." behavior.

## Related Issue

Closes #552

## Type of Change

- [x] `ci`: CI/CD configuration changes
- [x] `chore`: Other changes (maintenance, tooling, etc.)

## Checklist

- [x] My PR title follows the [Conventional Commits](https://conventionalcommits.org) format (e.g., `feat: add new feature` or `fix: resolve issue`)
- [x] I have read and followed the [Code of Conduct](../CODE_OF_CONDUCT.md)
- [x] My code follows the project's code style (linting passes)
- [x] I have added/updated documentation as needed
- [x] Any dependent changes have been merged and published

## Testing

- Ran `pre-commit run --files .github/workflows/transifex.yml` — all hooks pass (`check-yaml`, `sp-repo-review`, `zizmor`, `codespell`).
- The `zizmor` security scan passes with `persist-credentials: false` and the SHA-pinned action.

## Additional Notes

The PR opened by the workflow will still need to pass the 11 required status checks before it can be merged, consistent with the repository rules. A maintainer (or an auto-merge policy) can merge it once checks are green.
